### PR TITLE
Rework memory

### DIFF
--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -436,8 +436,10 @@ impl<'chunk> InstructionDisassembler<'chunk> {
             offset += 1;
             writeln!(
                 f,
-                "{:04}    |                     {} {}",
+                "{:04}    |{} {} {}",
                 offset - 2,
+                // +1 for the space before opcode_name and 1 between name and operand
+                " ".repeat(self.opcode_name_alignment + self.operand_aligment + 2),
                 if is_local { "local" } else { "upvalue" },
                 index
             )?;

--- a/src/compiler/back.rs
+++ b/src/compiler/back.rs
@@ -44,8 +44,7 @@ impl<'scanner, 'heap> Compiler<'scanner, 'heap> {
         T: Into<Value>,
     {
         let line = self.line();
-        let value_id = self.heap.add_value(value.into());
-        if !self.current_chunk().write_constant(value_id, line) {
+        if !self.current_chunk().write_constant(value.into(), line) {
             self.error("Too many constants in one chunk.");
         }
     }

--- a/src/compiler/front.rs
+++ b/src/compiler/front.rs
@@ -106,8 +106,8 @@ impl<'scanner, 'heap> Compiler<'scanner, 'heap> {
 
         self.emit_byte(OpCode::Closure, line);
         let function_id = self.heap.add_function(nested_function);
-        let value_id = self.heap.add_value(function_id.into());
-        let value_id_byte = u8::try_from(self.current_chunk().make_constant(value_id).0).unwrap();
+        let value_id_byte =
+            u8::try_from(self.current_chunk().make_constant(function_id).0).unwrap();
         self.emit_byte(value_id_byte, line);
 
         for upvalue in nested_upvalues {

--- a/src/compiler/rules.rs
+++ b/src/compiler/rules.rs
@@ -202,7 +202,9 @@ impl<'scanner, 'arena> Compiler<'scanner, 'arena> {
         let rule = self.get_rule(operator);
 
         self.parse_precedence(
-            Precedence::try_from_primitive(u8::from(rule.precedence) + 1).unwrap(),
+            Precedence::try_from_primitive(u8::from(rule.precedence) + 1).expect(
+                "Invalid precendence in 'binary', should never be called for `Primary expression`.",
+            ),
         );
 
         match operator {

--- a/src/compiler/variables.rs
+++ b/src/compiler/variables.rs
@@ -133,8 +133,7 @@ impl<'scanner, 'arena> Compiler<'scanner, 'arena> {
         if let Some(index) = self.globals_by_name().get(&string_id) {
             *index
         } else {
-            let value_id = self.heap.add_value(string_id.into());
-            let index = self.current_chunk().make_constant(value_id);
+            let index = self.current_chunk().make_constant(string_id.into());
             self.globals_by_name_mut().insert(string_id, index);
             index
         }

--- a/src/compiler/variables.rs
+++ b/src/compiler/variables.rs
@@ -125,6 +125,9 @@ impl<'scanner, 'arena> Compiler<'scanner, 'arena> {
         }
     }
 
+    // Because the closure would need unique access to self while it
+    // is mutably borrowed.
+    #[allow(clippy::option_if_let_else)]
     pub(super) fn identifier_constant<S>(&mut self, name: &S) -> ConstantLongIndex
     where
         S: ToString,

--- a/src/compiler/variables.rs
+++ b/src/compiler/variables.rs
@@ -227,7 +227,7 @@ impl<'scanner, 'arena> Compiler<'scanner, 'arena> {
             u8::try_from(upvalue_count - 1).unwrap()
         } else {
             // This is where `(Get|Set)UpvalueLong` would go
-            self.error("Too variables in function surrounding closure.");
+            self.error("Too many variables in function surrounding closure.");
             0
         }
     }

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -669,7 +669,7 @@ impl Heap {
         let function = &item.item;
         self.strings.gray.push(function.name.id);
         for constant in function.chunk.constants() {
-            gray_value!(self, constant)
+            gray_value!(self, constant);
         }
         if self.log_gc {
             eprintln!("Function/{:?} blacken {} end", index, item.item);

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -589,6 +589,8 @@ impl Heap {
         }
     }
 
+    // I guess this has issues with the macro?
+    #[allow(clippy::cognitive_complexity)]
     fn blacken_bound_method(&mut self, index: BoundMethodKey) {
         let item = &mut self.bound_methods.data[index];
         if item.marked == self.black_value {

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -467,7 +467,7 @@ impl Heap {
         match &item.item {
             Upvalue::Open(_) => {}
             Upvalue::Closed(value) => {
-                gray_value!(self, &*value.borrow());
+                gray_value!(self, value);
             }
         }
         if self.log_gc {

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -467,7 +467,7 @@ impl Heap {
         match &item.item {
             Upvalue::Open(_) => {}
             Upvalue::Closed(value) => {
-                gray_value!(self, value);
+                gray_value!(self, &*value.borrow());
             }
         }
         if self.log_gc {

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -38,6 +38,10 @@ pub struct ArenaId<K: Key, T: ArenaValue> {
     id: K,
     #[derivative(Hash = "ignore")]
     pub arena: NonNull<Arena<K, T>>, // Yes this is terrible, yes I'm OK with it for this projec
+                                     // These could be but then i would have to put `clones` everywhere.
+                                     // use std::cell::RefCell;
+                                     // use std::rc::Rc;
+                                     // pub arena: Rc<RefCell<Arena<K, T>>>,
 }
 
 impl<K: Key, T: ArenaValue> PartialEq for ArenaId<K, T> {

--- a/src/native_functions.rs
+++ b/src/native_functions.rs
@@ -15,7 +15,7 @@ use crate::{
     vm::VM,
 };
 
-fn clock_native(heap: &mut Heap, _args: &[&Value]) -> Result<Value, String> {
+fn clock_native(_heap: &mut Heap, _args: &mut [&mut Value]) -> Result<Value, String> {
     Ok(Value::Number(
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -25,8 +25,8 @@ fn clock_native(heap: &mut Heap, _args: &[&Value]) -> Result<Value, String> {
     ))
 }
 
-fn sleep_native(heap: &mut Heap, args: &[&Value]) -> Result<Value, String> {
-    match args[0] {
+fn sleep_native(_heap: &mut Heap, args: &mut [&mut Value]) -> Result<Value, String> {
+    match &args[0] {
         Value::Number(Number::Integer(i)) if i >= &0 => {
             thread::sleep(Duration::from_secs(ias_u64(*i)));
         }
@@ -40,8 +40,8 @@ fn sleep_native(heap: &mut Heap, args: &[&Value]) -> Result<Value, String> {
     Ok(Value::Nil)
 }
 
-fn assert_native(heap: &mut Heap, args: &[&Value]) -> Result<Value, String> {
-    let value = args[0];
+fn assert_native(_heap: &mut Heap, args: &mut [&mut Value]) -> Result<Value, String> {
+    let value = &args[0];
     if value.is_falsey() {
         Err(format!("Assertion on `{value}` failed!"))
     } else {
@@ -49,15 +49,15 @@ fn assert_native(heap: &mut Heap, args: &[&Value]) -> Result<Value, String> {
     }
 }
 
-fn sqrt_native(heap: &mut Heap, args: &[&Value]) -> Result<Value, String> {
-    match args[0] {
+fn sqrt_native(_heap: &mut Heap, args: &mut [&mut Value]) -> Result<Value, String> {
+    match &args[0] {
         Value::Number(Number::Float(n)) => Ok(n.sqrt().into()),
         Value::Number(Number::Integer(n)) => Ok((ias_f64(*n)).sqrt().into()),
         x => Err(format!("'sqrt' expected numeric argument, got: {}", *x)),
     }
 }
 
-fn input_native(heap: &mut Heap, args: &[&Value]) -> Result<Value, String> {
+fn input_native(heap: &mut Heap, args: &mut [&mut Value]) -> Result<Value, String> {
     match &args[0] {
         Value::String(prompt) => {
             println!("{}", &heap.strings[prompt]);
@@ -75,8 +75,8 @@ fn input_native(heap: &mut Heap, args: &[&Value]) -> Result<Value, String> {
 }
 
 #[allow(clippy::option_if_let_else)]
-fn to_float_native(heap: &mut Heap, args: &[&Value]) -> Result<Value, String> {
-    match args[0] {
+fn to_float_native(heap: &mut Heap, args: &mut [&mut Value]) -> Result<Value, String> {
+    match &args[0] {
         Value::String(string_id) => {
             let string = &heap.strings[string_id];
             let converted: Result<f64, _> = string.parse();
@@ -96,8 +96,8 @@ fn to_float_native(heap: &mut Heap, args: &[&Value]) -> Result<Value, String> {
 }
 
 #[allow(clippy::option_if_let_else)]
-fn to_int_native(heap: &mut Heap, args: &[&Value]) -> Result<Value, String> {
-    match args[0] {
+fn to_int_native(heap: &mut Heap, args: &mut [&mut Value]) -> Result<Value, String> {
+    match &args[0] {
         Value::String(string_id) => {
             let string = &heap.strings[string_id];
             let converted: Result<i64, _> = string.parse();
@@ -117,8 +117,8 @@ fn to_int_native(heap: &mut Heap, args: &[&Value]) -> Result<Value, String> {
 }
 
 #[allow(clippy::option_if_let_else)]
-fn is_int_native(heap: &mut Heap, args: &[&Value]) -> Result<Value, String> {
-    match args[0] {
+fn is_int_native(heap: &mut Heap, args: &mut [&mut Value]) -> Result<Value, String> {
+    match &args[0] {
         Value::String(string_id) => {
             let string = &heap.strings[string_id];
             let converted: Result<i64, _> = string.parse();
@@ -132,14 +132,14 @@ fn is_int_native(heap: &mut Heap, args: &[&Value]) -> Result<Value, String> {
     }
 }
 
-fn to_string_native(heap: &mut Heap, args: &[&Value]) -> Result<Value, String> {
-    let value = args[0];
+fn to_string_native(heap: &mut Heap, args: &mut [&mut Value]) -> Result<Value, String> {
+    let value = &args[0];
     let string = Value::String(heap.string_id(&value.to_string()));
     Ok(string)
 }
 
-fn type_native(heap: &mut Heap, args: &[&Value]) -> Result<Value, String> {
-    let string = match args[0] {
+fn type_native(heap: &mut Heap, args: &mut [&mut Value]) -> Result<Value, String> {
+    let string = match &args[0] {
         Value::Bool(_) => Value::String(heap.string_id(&"<type bool>")),
         Value::BoundMethod(_) => Value::String(heap.string_id(&"<type bound method>")),
         Value::Class(_) => Value::String(heap.string_id(&"<type class>")),
@@ -162,9 +162,9 @@ fn type_native(heap: &mut Heap, args: &[&Value]) -> Result<Value, String> {
     Ok(string)
 }
 
-fn print_native(heap: &mut Heap, args: &[&Value]) -> Result<Value, String> {
+fn print_native(heap: &mut Heap, args: &mut [&mut Value]) -> Result<Value, String> {
     let end = if args.len() == 2 {
-        match args[1] {
+        match &args[1] {
             Value::String(string_id) => &heap.strings[string_id],
             x => {
                 return Err(format!(
@@ -175,13 +175,13 @@ fn print_native(heap: &mut Heap, args: &[&Value]) -> Result<Value, String> {
     } else {
         "\n"
     };
-    let value = args[0];
+    let value = &args[0];
     print!("{value}{end}");
     Ok(Value::Nil)
 }
 
-fn rng_native(heap: &mut Heap, args: &[&Value]) -> Result<Value, String> {
-    match (args[0], args[1]) {
+fn rng_native(_heap: &mut Heap, args: &mut [&mut Value]) -> Result<Value, String> {
+    match (&args[0], &args[1]) {
         (Value::Number(Number::Integer(min)), Value::Number(Number::Integer(max))) => Ok(
             Value::Number(rand::thread_rng().gen_range(*min..*max).into()),
         ),
@@ -194,13 +194,17 @@ fn rng_native(heap: &mut Heap, args: &[&Value]) -> Result<Value, String> {
 fn init_list_native(
     heap: &mut Heap,
     _receiver: &mut Value,
-    _args: &[&Value],
+    _args: &mut [&mut Value],
 ) -> Result<Value, String> {
     let list = List::new(*heap.native_classes.get("List").unwrap());
     Ok(heap.add_list(list))
 }
 
-fn append_native(heap: &mut Heap, receiver: &mut Value, args: &[&Value]) -> Result<Value, String> {
+fn append_native(
+    _heap: &mut Heap,
+    receiver: &mut Value,
+    args: &mut [&mut Value],
+) -> Result<Value, String> {
     match receiver {
         Value::List(list) => {
             list.items.push(*args[0]);
@@ -212,11 +216,15 @@ fn append_native(heap: &mut Heap, receiver: &mut Value, args: &[&Value]) -> Resu
     }
 }
 
-fn pop_native(heap: &mut Heap, receiver: &mut Value, args: &[&Value]) -> Result<Value, String> {
+fn pop_native(
+    _heap: &mut Heap,
+    receiver: &mut Value,
+    args: &mut [&mut Value],
+) -> Result<Value, String> {
     let index = if args.is_empty() {
         None
     } else {
-        let index = match args[0] {
+        let index = match &args[0] {
             Value::Number(Number::Integer(n)) => match usize::try_from(*n) {
                 Ok(index) => index,
                 Err(_) => {
@@ -259,8 +267,12 @@ fn pop_native(heap: &mut Heap, receiver: &mut Value, args: &[&Value]) -> Result<
     }
 }
 
-fn insert_native(heap: &mut Heap, receiver: &mut Value, args: &[&Value]) -> Result<Value, String> {
-    let index = match args[0] {
+fn insert_native(
+    _heap: &mut Heap,
+    receiver: &mut Value,
+    args: &mut [&mut Value],
+) -> Result<Value, String> {
+    let index = match &args[0] {
         Value::Number(Number::Integer(n)) => match usize::try_from(*n) {
             Ok(index) => index,
             Err(_) => {
@@ -295,9 +307,9 @@ fn insert_native(heap: &mut Heap, receiver: &mut Value, args: &[&Value]) -> Resu
 }
 
 fn contains_native(
-    heap: &mut Heap,
+    _heap: &mut Heap,
     receiver: &mut Value,
-    args: &[&Value],
+    args: &mut [&mut Value],
 ) -> Result<Value, String> {
     let my_list = match receiver {
         Value::List(list) => list,
@@ -317,15 +329,15 @@ fn contains_native(
 }
 
 #[allow(clippy::cast_possible_wrap)]
-fn len_native(heap: &mut Heap, args: &[&Value]) -> Result<Value, String> {
-    match args[0] {
+fn len_native(_heap: &mut Heap, args: &mut [&mut Value]) -> Result<Value, String> {
+    match &args[0] {
         Value::List(list) => Ok((list.items.len() as i64).into()),
         x => Err(format!("'len' expected list argument, got: `{x}` instead.")),
     }
 }
 
-fn getattr_native(heap: &mut Heap, args: &[&Value]) -> Result<Value, String> {
-    match (args[0], args[1]) {
+fn getattr_native(heap: &mut Heap, args: &mut [&mut Value]) -> Result<Value, String> {
+    match (&args[0], &args[1]) {
         (Value::Instance(instance), Value::String(string_id)) => {
             let field = &heap.strings[string_id];
             instance.fields.get(field).map_or_else(
@@ -342,28 +354,29 @@ fn getattr_native(heap: &mut Heap, args: &[&Value]) -> Result<Value, String> {
     }
 }
 
-fn setattr_native(heap: &mut Heap, args: &[&Value]) -> Result<Value, String> {
-    if let Value::String(string_id) = args[1] {
-        let field = heap.strings[string_id].clone();
-        if let Value::Instance(instance) = args[0] {
-            instance.fields.insert(field, *args[2]);
-            Ok(Value::Nil)
-        } else {
-            Err(format!(
-                "`setattr` only works on instances, got `{}`",
-                args[0]
-            ))
-        }
+fn setattr_native(heap: &mut Heap, args: &mut [&mut Value]) -> Result<Value, String> {
+    let field = if let Value::String(ref string_id) = args[1] {
+        heap.strings[string_id].clone()
     } else {
-        Err(format!(
+        return Err(format!(
             "`setattr` can only index with string indexes, got: `{}` (instance: `{}`)",
             args[1], args[0]
+        ));
+    };
+    let value = *args[2];
+    if let Value::Instance(instance) = args[0] {
+        instance.fields.insert(field, value);
+        Ok(Value::Nil)
+    } else {
+        Err(format!(
+            "`setattr` only works on instances, got `{}`",
+            args[0]
         ))
     }
 }
 
-fn hasattr_native(heap: &mut Heap, args: &[&Value]) -> Result<Value, String> {
-    match (args[0], args[1]) {
+fn hasattr_native(heap: &mut Heap, args: &mut [&mut Value]) -> Result<Value, String> {
+    match (&args[0], &args[1]) {
         (Value::Instance(instance), Value::String(string_id)) => Ok(Value::Bool(
             instance.fields.contains_key(&heap.strings[string_id]),
         )),
@@ -376,8 +389,8 @@ fn hasattr_native(heap: &mut Heap, args: &[&Value]) -> Result<Value, String> {
     }
 }
 
-fn delattr_native(heap: &mut Heap, args: &[&Value]) -> Result<Value, String> {
-    if let Value::String(string_id) = args[1] {
+fn delattr_native(heap: &mut Heap, args: &mut [&mut Value]) -> Result<Value, String> {
+    if let Value::String(ref string_id) = args[1] {
         let field = &heap.strings[string_id];
         if let Value::Instance(instance) = args[0] {
             match instance.fields.remove(field) {

--- a/src/native_functions.rs
+++ b/src/native_functions.rs
@@ -10,23 +10,23 @@ use rustc_hash::FxHashMap as HashMap;
 
 use crate::{
     compiler::Compiler,
-    heap::{Heap, StringId, ValueId},
+    heap::{Heap, StringId},
     value::{ias_f64, ias_u64, List, Number, Value},
     vm::VM,
 };
 
-fn clock_native(heap: &mut Heap, _args: &[&ValueId]) -> Result<ValueId, String> {
-    Ok(heap.add_value(Value::Number(
+fn clock_native(heap: &mut Heap, _args: &[&Value]) -> Result<Value, String> {
+    Ok(Value::Number(
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_secs_f64()
             .into(),
-    )))
+    ))
 }
 
-fn sleep_native(heap: &mut Heap, args: &[&ValueId]) -> Result<ValueId, String> {
-    match &heap.values[args[0]] {
+fn sleep_native(heap: &mut Heap, args: &[&Value]) -> Result<Value, String> {
+    match args[0] {
         Value::Number(Number::Integer(i)) if i >= &0 => {
             thread::sleep(Duration::from_secs(ias_u64(*i)));
         }
@@ -37,35 +37,35 @@ fn sleep_native(heap: &mut Heap, args: &[&ValueId]) -> Result<ValueId, String> {
             ));
         }
     };
-    Ok(heap.builtin_constants().nil)
+    Ok(Value::Nil)
 }
 
-fn assert_native(heap: &mut Heap, args: &[&ValueId]) -> Result<ValueId, String> {
-    let value = &heap.values[args[0]];
+fn assert_native(heap: &mut Heap, args: &[&Value]) -> Result<Value, String> {
+    let value = args[0];
     if value.is_falsey() {
         Err(format!("Assertion on `{value}` failed!"))
     } else {
-        Ok(heap.builtin_constants().nil)
+        Ok(Value::Nil)
     }
 }
 
-fn sqrt_native(heap: &mut Heap, args: &[&ValueId]) -> Result<ValueId, String> {
-    match &heap.values[args[0]] {
-        Value::Number(Number::Float(n)) => Ok(heap.add_value(n.sqrt().into())),
-        Value::Number(Number::Integer(n)) => Ok(heap.add_value((ias_f64(*n)).sqrt().into())),
+fn sqrt_native(heap: &mut Heap, args: &[&Value]) -> Result<Value, String> {
+    match args[0] {
+        Value::Number(Number::Float(n)) => Ok(n.sqrt().into()),
+        Value::Number(Number::Integer(n)) => Ok((ias_f64(*n)).sqrt().into()),
         x => Err(format!("'sqrt' expected numeric argument, got: {}", *x)),
     }
 }
 
-fn input_native(heap: &mut Heap, args: &[&ValueId]) -> Result<ValueId, String> {
-    match &heap.values[args[0]] {
+fn input_native(heap: &mut Heap, args: &[&Value]) -> Result<Value, String> {
+    match &args[0] {
         Value::String(prompt) => {
             println!("{}", &heap.strings[prompt]);
             let mut choice = String::new();
             match io::stdin().read_line(&mut choice) {
                 Ok(_) => {
                     let string = Value::String(heap.string_id(&choice.trim()));
-                    Ok(heap.add_value(string))
+                    Ok(string)
                 }
                 Err(e) => Err(format!("'input' could not read line: {e}")),
             }
@@ -75,20 +75,20 @@ fn input_native(heap: &mut Heap, args: &[&ValueId]) -> Result<ValueId, String> {
 }
 
 #[allow(clippy::option_if_let_else)]
-fn to_float_native(heap: &mut Heap, args: &[&ValueId]) -> Result<ValueId, String> {
-    match &heap.values[args[0]] {
+fn to_float_native(heap: &mut Heap, args: &[&Value]) -> Result<Value, String> {
+    match args[0] {
         Value::String(string_id) => {
             let string = &heap.strings[string_id];
             let converted: Result<f64, _> = string.parse();
             match converted {
-                Ok(result) => Ok(heap.add_value(Value::Number(result.into()))),
+                Ok(result) => Ok(Value::Number(result.into())),
                 Err(_) => Err(format!(
                     "'float' could not convert string '{string}' to a float."
                 )),
             }
         }
-        Value::Number(n) => Ok(heap.add_value(Value::Number(f64::from(*n).into()))),
-        Value::Bool(value) => Ok(heap.add_value(Value::Number(f64::from(*value).into()))),
+        Value::Number(n) => Ok(Value::Number(f64::from(*n).into())),
+        Value::Bool(value) => Ok(Value::Number(f64::from(*value).into())),
         x => Err(format!(
             "'float' expected string, number or bool argument, got: {x}"
         )),
@@ -96,20 +96,20 @@ fn to_float_native(heap: &mut Heap, args: &[&ValueId]) -> Result<ValueId, String
 }
 
 #[allow(clippy::option_if_let_else)]
-fn to_int_native(heap: &mut Heap, args: &[&ValueId]) -> Result<ValueId, String> {
-    match &heap.values[args[0]] {
+fn to_int_native(heap: &mut Heap, args: &[&Value]) -> Result<Value, String> {
+    match args[0] {
         Value::String(string_id) => {
             let string = &heap.strings[string_id];
             let converted: Result<i64, _> = string.parse();
             match converted {
-                Ok(result) => Ok(heap.add_value(Value::Number(result.into()))),
+                Ok(result) => Ok(Value::Number(result.into())),
                 Err(_) => Err(format!(
                     "'int' could not convert string '{string}' to an integer."
                 )),
             }
         }
-        Value::Number(n) => Ok(heap.add_value(Value::Number(i64::from(*n).into()))),
-        Value::Bool(value) => Ok(heap.add_value(Value::Number(i64::from(*value).into()))),
+        Value::Number(n) => Ok(Value::Number(i64::from(*n).into())),
+        Value::Bool(value) => Ok(Value::Number(i64::from(*value).into())),
         x => Err(format!(
             "'int' expected string, number or bool argument, got: {x}"
         )),
@@ -117,39 +117,36 @@ fn to_int_native(heap: &mut Heap, args: &[&ValueId]) -> Result<ValueId, String> 
 }
 
 #[allow(clippy::option_if_let_else)]
-fn is_int_native(heap: &mut Heap, args: &[&ValueId]) -> Result<ValueId, String> {
-    match &heap.values[args[0]] {
+fn is_int_native(heap: &mut Heap, args: &[&Value]) -> Result<Value, String> {
+    match args[0] {
         Value::String(string_id) => {
             let string = &heap.strings[string_id];
             let converted: Result<i64, _> = string.parse();
             match converted {
-                Ok(_) => Ok(heap.builtin_constants().true_),
-                Err(_) => Ok(heap.builtin_constants().false_),
+                Ok(_) => Ok(Value::Bool(true)),
+                Err(_) => Ok(Value::Bool(false)),
             }
         }
-        Value::Number(n) => Ok(heap.add_value(Value::Number(i64::from(*n).into()))),
-        Value::Bool(value) => Ok(heap.add_value(Value::Number(i64::from(*value).into()))),
-        x => Err(format!(
-            "'int' expected string, number or bool argument, got: {x}"
-        )),
+        Value::Number(_) | Value::Bool(_) => Ok(Value::Bool(true)),
+        _ => Ok(Value::Bool(false)),
     }
 }
 
-fn to_string_native(heap: &mut Heap, args: &[&ValueId]) -> Result<ValueId, String> {
-    let value = &heap.values[args[0]];
+fn to_string_native(heap: &mut Heap, args: &[&Value]) -> Result<Value, String> {
+    let value = args[0];
     let string = Value::String(heap.string_id(&value.to_string()));
-    Ok(heap.add_value(string))
+    Ok(string)
 }
 
-fn type_native(heap: &mut Heap, args: &[&ValueId]) -> Result<ValueId, String> {
-    let string = match &heap.values[args[0]] {
+fn type_native(heap: &mut Heap, args: &[&Value]) -> Result<Value, String> {
+    let string = match args[0] {
         Value::Bool(_) => Value::String(heap.string_id(&"<type bool>")),
         Value::BoundMethod(_) => Value::String(heap.string_id(&"<type bound method>")),
         Value::Class(_) => Value::String(heap.string_id(&"<type class>")),
         Value::Closure(_) => Value::String(heap.string_id(&"<type closure>")),
         Value::Function(_) => Value::String(heap.string_id(&"<type function>")),
         Value::Instance(instance) => Value::String(
-            heap.string_id(&("<type ".to_string() + instance.class.as_class().name.as_str() + ">")),
+            heap.string_id(&("<type ".to_string() + instance.class.name.as_str() + ">")),
         ),
         Value::NativeFunction(_) => Value::String(heap.string_id(&"<type native function>")),
         Value::NativeMethod(_) => Value::String(heap.string_id(&"<type native method>")),
@@ -162,12 +159,12 @@ fn type_native(heap: &mut Heap, args: &[&ValueId]) -> Result<ValueId, String> {
         Value::Upvalue(_) => Value::String(heap.string_id(&"<type upvalue>")),
         Value::List(_) => Value::String(heap.string_id(&"<type list>")),
     };
-    Ok(heap.add_value(string))
+    Ok(string)
 }
 
-fn print_native(heap: &mut Heap, args: &[&ValueId]) -> Result<ValueId, String> {
+fn print_native(heap: &mut Heap, args: &[&Value]) -> Result<Value, String> {
     let end = if args.len() == 2 {
-        match &heap.values[args[1]] {
+        match args[1] {
             Value::String(string_id) => &heap.strings[string_id],
             x => {
                 return Err(format!(
@@ -178,17 +175,16 @@ fn print_native(heap: &mut Heap, args: &[&ValueId]) -> Result<ValueId, String> {
     } else {
         "\n"
     };
-    let value = &heap.values[args[0]];
+    let value = args[0];
     print!("{value}{end}");
-    Ok(heap.builtin_constants().nil)
+    Ok(Value::Nil)
 }
 
-fn rng_native(heap: &mut Heap, args: &[&ValueId]) -> Result<ValueId, String> {
-    match (&heap.values[args[0]], &heap.values[args[1]]) {
-        (Value::Number(Number::Integer(min)), Value::Number(Number::Integer(max))) => Ok(heap
-            .add_value(Value::Number(
-                rand::thread_rng().gen_range(*min..*max).into(),
-            ))),
+fn rng_native(heap: &mut Heap, args: &[&Value]) -> Result<Value, String> {
+    match (args[0], args[1]) {
+        (Value::Number(Number::Integer(min)), Value::Number(Number::Integer(max))) => Ok(
+            Value::Number(rand::thread_rng().gen_range(*min..*max).into()),
+        ),
         (other_1, other_2) => Err(format!(
             "'rng' expected two integers as arguments, got: `{other_1}` and `{other_2}` instead."
         )),
@@ -197,22 +193,18 @@ fn rng_native(heap: &mut Heap, args: &[&ValueId]) -> Result<ValueId, String> {
 
 fn init_list_native(
     heap: &mut Heap,
-    _receiver: &ValueId,
-    _args: &[&ValueId],
-) -> Result<ValueId, String> {
+    _receiver: &mut Value,
+    _args: &[&Value],
+) -> Result<Value, String> {
     let list = List::new(*heap.native_classes.get("List").unwrap());
-    Ok(heap.add_value(list.into()))
+    Ok(heap.add_list(list))
 }
 
-fn append_native(
-    heap: &mut Heap,
-    receiver: &ValueId,
-    args: &[&ValueId],
-) -> Result<ValueId, String> {
-    match &mut heap.values[receiver] {
+fn append_native(heap: &mut Heap, receiver: &mut Value, args: &[&Value]) -> Result<Value, String> {
+    match receiver {
         Value::List(list) => {
             list.items.push(*args[0]);
-            Ok(heap.builtin_constants().nil)
+            Ok(Value::Nil)
         }
         x => Err(format!(
             "'append' expects its first argument to be a list, got `{x}` instead."
@@ -220,11 +212,11 @@ fn append_native(
     }
 }
 
-fn pop_native(heap: &mut Heap, receiver: &ValueId, args: &[&ValueId]) -> Result<ValueId, String> {
+fn pop_native(heap: &mut Heap, receiver: &mut Value, args: &[&Value]) -> Result<Value, String> {
     let index = if args.is_empty() {
         None
     } else {
-        let index = match &heap.values[args[0]] {
+        let index = match args[0] {
             Value::Number(Number::Integer(n)) => match usize::try_from(*n) {
                 Ok(index) => index,
                 Err(_) => {
@@ -240,7 +232,7 @@ fn pop_native(heap: &mut Heap, receiver: &ValueId, args: &[&ValueId]) -> Result<
         Some(index)
     };
 
-    let my_list = match &mut heap.values[receiver] {
+    let my_list = match receiver {
         Value::List(list) => list,
         x => {
             return Err(format!(
@@ -267,12 +259,8 @@ fn pop_native(heap: &mut Heap, receiver: &ValueId, args: &[&ValueId]) -> Result<
     }
 }
 
-fn insert_native(
-    heap: &mut Heap,
-    receiver: &ValueId,
-    args: &[&ValueId],
-) -> Result<ValueId, String> {
-    let index = match &heap.values[args[0]] {
+fn insert_native(heap: &mut Heap, receiver: &mut Value, args: &[&Value]) -> Result<Value, String> {
+    let index = match args[0] {
         Value::Number(Number::Integer(n)) => match usize::try_from(*n) {
             Ok(index) => index,
             Err(_) => {
@@ -286,7 +274,7 @@ fn insert_native(
         }
     };
 
-    let my_list = match &mut heap.values[receiver] {
+    let my_list = match receiver {
         Value::List(list) => list,
         x => {
             return Err(format!(
@@ -302,16 +290,16 @@ fn insert_native(
         ))
     } else {
         my_list.items.insert(index, *args[1]);
-        Ok(heap.builtin_constants().nil)
+        Ok(Value::Nil)
     }
 }
 
 fn contains_native(
     heap: &mut Heap,
-    receiver: &ValueId,
-    args: &[&ValueId],
-) -> Result<ValueId, String> {
-    let my_list = match &heap.values[receiver] {
+    receiver: &mut Value,
+    args: &[&Value],
+) -> Result<Value, String> {
+    let my_list = match receiver {
         Value::List(list) => list,
         x => {
             return Err(format!(
@@ -320,24 +308,24 @@ fn contains_native(
         }
     };
 
-    for value_id in &my_list.items {
-        if **value_id == heap.values[args[0]] {
-            return Ok(heap.builtin_constants().true_);
+    for value in &my_list.items {
+        if value == args[0] {
+            return Ok(Value::Bool(true));
         }
     }
-    Ok(heap.builtin_constants().false_)
+    Ok(Value::Bool(false))
 }
 
 #[allow(clippy::cast_possible_wrap)]
-fn len_native(heap: &mut Heap, args: &[&ValueId]) -> Result<ValueId, String> {
-    match &heap.values[args[0]] {
-        Value::List(list) => Ok(heap.add_value((list.items.len() as i64).into())),
+fn len_native(heap: &mut Heap, args: &[&Value]) -> Result<Value, String> {
+    match args[0] {
+        Value::List(list) => Ok((list.items.len() as i64).into()),
         x => Err(format!("'len' expected list argument, got: `{x}` instead.")),
     }
 }
 
-fn getattr_native(heap: &mut Heap, args: &[&ValueId]) -> Result<ValueId, String> {
-    match (&heap.values[args[0]], &heap.values[args[1]]) {
+fn getattr_native(heap: &mut Heap, args: &[&Value]) -> Result<Value, String> {
+    match (args[0], args[1]) {
         (Value::Instance(instance), Value::String(string_id)) => {
             let field = &heap.strings[string_id];
             instance.fields.get(field).map_or_else(
@@ -354,31 +342,31 @@ fn getattr_native(heap: &mut Heap, args: &[&ValueId]) -> Result<ValueId, String>
     }
 }
 
-fn setattr_native(heap: &mut Heap, args: &[&ValueId]) -> Result<ValueId, String> {
-    if let Value::String(string_id) = &heap.values[args[1]] {
+fn setattr_native(heap: &mut Heap, args: &[&Value]) -> Result<Value, String> {
+    if let Value::String(string_id) = args[1] {
         let field = heap.strings[string_id].clone();
-        if let Value::Instance(instance) = &mut heap.values[args[0]] {
+        if let Value::Instance(instance) = args[0] {
             instance.fields.insert(field, *args[2]);
-            Ok(heap.builtin_constants().nil)
+            Ok(Value::Nil)
         } else {
             Err(format!(
                 "`setattr` only works on instances, got `{}`",
-                heap.values[args[0]]
+                args[0]
             ))
         }
     } else {
         Err(format!(
             "`setattr` can only index with string indexes, got: `{}` (instance: `{}`)",
-            heap.values[args[1]], heap.values[args[0]]
+            args[1], args[0]
         ))
     }
 }
 
-fn hasattr_native(heap: &mut Heap, args: &[&ValueId]) -> Result<ValueId, String> {
-    match (&heap.values[args[0]], &heap.values[args[1]]) {
-        (Value::Instance(instance), Value::String(string_id)) => Ok(heap
-            .builtin_constants()
-            .bool(instance.fields.contains_key(&heap.strings[string_id]))),
+fn hasattr_native(heap: &mut Heap, args: &[&Value]) -> Result<Value, String> {
+    match (args[0], args[1]) {
+        (Value::Instance(instance), Value::String(string_id)) => Ok(Value::Bool(
+            instance.fields.contains_key(&heap.strings[string_id]),
+        )),
         (instance @ Value::Instance(_), x) => Err(format!(
             "`hasattr` can only index with string indexes, got: `{x}` (instance: `{instance}`)"
         )),
@@ -388,24 +376,24 @@ fn hasattr_native(heap: &mut Heap, args: &[&ValueId]) -> Result<ValueId, String>
     }
 }
 
-fn delattr_native(heap: &mut Heap, args: &[&ValueId]) -> Result<ValueId, String> {
-    if let Value::String(string_id) = &heap.values[args[1]] {
+fn delattr_native(heap: &mut Heap, args: &[&Value]) -> Result<Value, String> {
+    if let Value::String(string_id) = args[1] {
         let field = &heap.strings[string_id];
-        if let Value::Instance(instance) = &mut heap.values[args[0]] {
+        if let Value::Instance(instance) = args[0] {
             match instance.fields.remove(field) {
-                Some(_) => Ok(heap.builtin_constants().nil),
+                Some(_) => Ok(Value::Nil),
                 None => Err(format!("Undefined property '{field}'.")),
             }
         } else {
             Err(format!(
                 "`delattr` only works on instances, got `{}`",
-                heap.values[args[0]]
+                args[0]
             ))
         }
     } else {
         Err(format!(
             "`delattr` can only index with string indexes, got: `{}` (instance: `{}`)",
-            heap.values[args[1]], heap.values[args[0]]
+            args[1], args[0]
         ))
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -263,7 +263,7 @@ pub struct Closure {
 
 impl std::fmt::Display for Closure {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.pad(&format!("<fn {}>", *self.function))
+        f.pad(&format!("{}", *self.function))
     }
 }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -9,7 +9,7 @@ use derivative::Derivative;
 use derive_more::{From, Neg};
 use rustc_hash::FxHashMap as HashMap;
 
-#[derive(Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Debug, PartialEq, PartialOrd, Clone, Copy)]
 pub enum Value {
     Bool(bool),
     Nil,

--- a/src/value.rs
+++ b/src/value.rs
@@ -287,7 +287,7 @@ impl Closure {
 }
 
 impl Value {
-    pub fn bound_method(receiver: Value, method: Value, heap: &mut Heap) -> Self {
+    pub fn bound_method(receiver: Self, method: Self, heap: &mut Heap) -> Self {
         heap.add_bound_method(BoundMethod { receiver, method })
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -39,15 +39,15 @@ impl std::fmt::Display for Value {
             Self::Nil => f.pad("nil"),
             Self::String(s) => f.pad(s),
             // Can i do all of these just like string?
-            Self::Function(refId) => f.pad(&format!("{}", **refId)),
-            Self::Closure(refId) => f.pad(&format!("{}", **refId)),
-            Self::NativeFunction(refId) => f.pad(&format!("{}", **refId)),
-            Self::NativeMethod(refId) => f.pad(&format!("{}", **refId)),
-            Self::Class(refId) => f.pad(&format!("{}", **refId)),
-            Self::Instance(refId) => f.pad(&format!("{}", **refId)),
-            Self::BoundMethod(refId) => f.pad(&format!("{}", **refId)),
-            Self::List(refId) => f.pad(&format!("{}", **refId)),
-            Self::Upvalue(refId) => f.pad(&format!("{}", **refId)),
+            Self::Function(ref_id) => f.pad(&format!("{}", **ref_id)),
+            Self::Closure(ref_id) => f.pad(&format!("{}", **ref_id)),
+            Self::NativeFunction(ref_id) => f.pad(&format!("{}", **ref_id)),
+            Self::NativeMethod(ref_id) => f.pad(&format!("{}", **ref_id)),
+            Self::Class(ref_id) => f.pad(&format!("{}", **ref_id)),
+            Self::Instance(ref_id) => f.pad(&format!("{}", **ref_id)),
+            Self::BoundMethod(ref_id) => f.pad(&format!("{}", **ref_id)),
+            Self::List(ref_id) => f.pad(&format!("{}", **ref_id)),
+            Self::Upvalue(ref_id) => f.pad(&format!("{}", **ref_id)),
         }
     }
 }
@@ -287,7 +287,7 @@ impl Closure {
 }
 
 impl Value {
-    pub const fn bound_method(receiver: Value, method: Value, heap: &mut Heap) -> Self {
+    pub fn bound_method(receiver: Value, method: Value, heap: &mut Heap) -> Self {
         heap.add_bound_method(BoundMethod { receiver, method })
     }
 }
@@ -407,8 +407,8 @@ impl std::fmt::Display for NativeMethod {
     }
 }
 
-pub type NativeFunctionImpl = fn(&mut Heap, &[&Value]) -> Result<Value, String>;
-pub type NativeMethodImpl = fn(&mut Heap, &mut Value, &[&Value]) -> Result<Value, String>;
+pub type NativeFunctionImpl = fn(&mut Heap, &mut [&mut Value]) -> Result<Value, String>;
+pub type NativeMethodImpl = fn(&mut Heap, &mut Value, &mut [&mut Value]) -> Result<Value, String>;
 
 const fn always_equals<T>(_: &T, _: &T) -> bool {
     true
@@ -481,7 +481,7 @@ pub struct List {
 
 impl List {
     #[must_use]
-    pub const fn new(array_class: Value) -> Self {
+    pub fn new(array_class: Value) -> Self {
         Self {
             items: Vec::new(),
             class: *array_class.as_class(),
@@ -646,13 +646,6 @@ impl Value {
     }
 
     pub fn upvalue_location(&self) -> &UpvalueId {
-        match self {
-            Self::Upvalue(v) => v,
-            _ => unreachable!("Expected upvalue, found `{}`", self),
-        }
-    }
-
-    pub fn upvalue_location_mut(&mut self) -> &mut UpvalueId {
         match self {
             Self::Upvalue(v) => v,
             _ => unreachable!("Expected upvalue, found `{}`", self),

--- a/src/value.rs
+++ b/src/value.rs
@@ -8,7 +8,6 @@ use crate::{
 use derivative::Derivative;
 use derive_more::{From, Neg};
 use rustc_hash::FxHashMap as HashMap;
-use std::cell::RefCell;
 
 #[derive(Debug, PartialEq, PartialOrd, Clone, Copy)]
 pub enum Value {
@@ -236,7 +235,7 @@ impl ::core::ops::Rem for Number {
 #[derive(Debug, PartialEq, PartialOrd, Clone)]
 pub enum Upvalue {
     Open(usize),
-    Closed(RefCell<Value>),
+    Closed(Value),
 }
 
 impl std::fmt::Display for Upvalue {

--- a/src/value.rs
+++ b/src/value.rs
@@ -8,6 +8,7 @@ use crate::{
 use derivative::Derivative;
 use derive_more::{From, Neg};
 use rustc_hash::FxHashMap as HashMap;
+use std::cell::RefCell;
 
 #[derive(Debug, PartialEq, PartialOrd, Clone, Copy)]
 pub enum Value {
@@ -235,7 +236,7 @@ impl ::core::ops::Rem for Number {
 #[derive(Debug, PartialEq, PartialOrd, Clone)]
 pub enum Upvalue {
     Open(usize),
-    Closed(Value),
+    Closed(RefCell<Value>),
 }
 
 impl std::fmt::Display for Upvalue {

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,6 +1,9 @@
 use crate::{
     chunk::Chunk,
-    heap::{FunctionId, Heap, StringId, ValueId},
+    heap::{
+        BoundMethodId, ClassId, ClosureId, FunctionId, Heap, InstanceId, ListId, NativeFunctionId,
+        NativeMethodId, StringId, UpvalueId,
+    },
 };
 use derivative::Derivative;
 use derive_more::{From, Neg};
@@ -15,17 +18,38 @@ pub enum Value {
     String(StringId),
 
     Function(FunctionId),
-    Closure(Closure),
-    NativeFunction(NativeFunction),
-    NativeMethod(NativeMethod),
+    Closure(ClosureId),
+    NativeFunction(NativeFunctionId),
+    NativeMethod(NativeMethodId),
 
-    Upvalue(Upvalue),
+    Upvalue(UpvalueId),
 
-    Class(Class),
-    Instance(Instance),
-    BoundMethod(BoundMethod),
+    Class(ClassId),
+    Instance(InstanceId),
+    BoundMethod(BoundMethodId),
 
-    List(List),
+    List(ListId),
+}
+
+impl std::fmt::Display for Value {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Bool(bool) => f.pad(&format!("{bool}")),
+            Self::Number(num) => f.pad(&format!("{num}")),
+            Self::Nil => f.pad("nil"),
+            Self::String(s) => f.pad(s),
+            // Can i do all of these just like string?
+            Self::Function(refId) => f.pad(&format!("{}", **refId)),
+            Self::Closure(refId) => f.pad(&format!("{}", **refId)),
+            Self::NativeFunction(refId) => f.pad(&format!("{}", **refId)),
+            Self::NativeMethod(refId) => f.pad(&format!("{}", **refId)),
+            Self::Class(refId) => f.pad(&format!("{}", **refId)),
+            Self::Instance(refId) => f.pad(&format!("{}", **refId)),
+            Self::BoundMethod(refId) => f.pad(&format!("{}", **refId)),
+            Self::List(refId) => f.pad(&format!("{}", **refId)),
+            Self::Upvalue(refId) => f.pad(&format!("{}", **refId)),
+        }
+    }
 }
 
 #[derive(Debug, Copy, PartialEq, PartialOrd, Clone, From, Neg)]
@@ -208,10 +232,16 @@ impl ::core::ops::Rem for Number {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Clone)]
+#[derive(Debug, PartialEq, PartialOrd, Clone)]
 pub enum Upvalue {
     Open(usize),
-    Closed(ValueId),
+    Closed(Value),
+}
+
+impl std::fmt::Display for Upvalue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.pad("upvalue")
+    }
 }
 
 impl Upvalue {
@@ -226,9 +256,15 @@ impl Upvalue {
 #[derive(Debug, PartialOrd, Clone)]
 pub struct Closure {
     pub function: FunctionId,
-    pub upvalues: Vec<ValueId>,
+    pub upvalues: Vec<UpvalueId>,
     pub upvalue_count: usize,
     pub is_module: bool,
+}
+
+impl std::fmt::Display for Closure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.pad(&format!("<fn {}>", *self.function))
+    }
 }
 
 impl PartialEq for Closure {
@@ -251,190 +287,55 @@ impl Closure {
 }
 
 impl Value {
-    pub const fn bound_method(receiver: ValueId, method: ValueId) -> Self {
-        Self::BoundMethod(BoundMethod { receiver, method })
+    pub const fn bound_method(receiver: Value, method: Value, heap: &mut Heap) -> Self {
+        heap.add_bound_method(BoundMethod { receiver, method })
     }
 }
 
-impl From<bool> for Value {
-    fn from(b: bool) -> Self {
-        Self::Bool(b)
-    }
+#[derive(Debug, PartialOrd, Clone)]
+pub struct BoundMethod {
+    // Has to be a general Value because it can be an Instance or List
+    pub receiver: Value,
+    // Has to be a general Value because it can be a NativeMethod or Closure
+    pub method: Value,
 }
 
-impl From<f64> for Value {
-    fn from(f: f64) -> Self {
-        Self::Number(f.into())
-    }
-}
-
-impl From<i64> for Value {
-    fn from(f: i64) -> Self {
-        Self::Number(f.into())
-    }
-}
-
-impl From<StringId> for Value {
-    fn from(s: StringId) -> Self {
-        Self::String(s)
-    }
-}
-
-impl From<FunctionId> for Value {
-    fn from(f: FunctionId) -> Self {
-        Self::Function(f)
-    }
-}
-
-impl From<Closure> for Value {
-    fn from(c: Closure) -> Self {
-        Self::Closure(c)
-    }
-}
-
-impl From<Class> for Value {
-    fn from(c: Class) -> Self {
-        Self::Class(c)
-    }
-}
-
-impl From<Instance> for Value {
-    fn from(i: Instance) -> Self {
-        Self::Instance(i)
-    }
-}
-
-impl From<Number> for Value {
-    fn from(n: Number) -> Self {
-        Self::Number(n)
-    }
-}
-
-impl From<List> for Value {
-    fn from(l: List) -> Self {
-        Self::List(l)
-    }
-}
-
-impl std::fmt::Display for Value {
+impl std::fmt::Display for BoundMethod {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Bool(bool) => f.pad(&format!("{bool}")),
-            Self::Number(num) => f.pad(&format!("{num}")),
-            Self::Nil => f.pad("nil"),
-            Self::String(s) => f.pad(s),
-            Self::Function(function_id) => f.pad(&format!("<fn {}>", *function_id.name)),
-            Self::Closure(closure) => f.pad(&format!("<fn {}>", *closure.function.name)),
-            Self::NativeFunction(fun) => f.pad(&format!("<native fn {}>", *fun.name)),
-            Self::NativeMethod(method) => f.pad(&format!(
-                "<native method {} of class {}>",
-                *method.name, *method.class
-            )),
-            Self::Upvalue(_) => f.pad("upvalue"),
-            Self::Class(c) => f.pad(&format!("<class {}>", *c.name)),
-            Self::Instance(instance) => f.pad(&format!(
-                "<{} instance>",
-                *(*instance.class).as_class().name
-            )),
-            Self::BoundMethod(method) => f.pad(&format!(
-                "<bound method {}.{} of {}>",
-                *method.receiver_class_name(),
-                *method.method_name(),
-                *method.receiver,
-            )),
-            Self::List(list) => f.pad(&{
-                let items = &list.items;
-                let mut comma_separated = String::new();
-                comma_separated.push('[');
-                if !items.is_empty() {
-                    for num in &items[0..items.len() - 1] {
-                        comma_separated.push_str(&num.to_string());
-                        comma_separated.push_str(", ");
-                    }
-
-                    comma_separated.push_str(&items[items.len() - 1].to_string());
-                }
-                comma_separated.push(']');
-                comma_separated
-            }),
-        }
+        f.pad(&format!(
+            "<bound method {}.{} of {}>",
+            *self.receiver_class_name(),
+            *self.method_name(),
+            self.receiver
+        ))
     }
 }
 
-impl Value {
-    pub const fn is_falsey(&self) -> bool {
-        matches!(self, Self::Bool(false) | Self::Nil)
-    }
-
-    pub fn as_closure(&self) -> &Closure {
-        match self {
-            Self::Closure(c) => c,
-            _ => unreachable!("Expected Closure, found `{}`", self),
-        }
-    }
-
-    pub fn as_native_method(&self) -> &NativeMethod {
-        match self {
-            Self::NativeMethod(n) => n,
-            _ => unreachable!("Expected Native, found `{}`", self),
-        }
-    }
-
-    pub fn as_function(&self) -> &FunctionId {
-        match self {
-            Self::Function(f) => f,
-            _ => unreachable!("Expected Function, found `{}`", self),
-        }
-    }
-
-    pub fn as_class(&self) -> &Class {
-        match self {
-            Self::Class(c) => c,
-            _ => unreachable!("Expected Class, found `{}`", self),
-        }
-    }
-
-    pub fn as_instance_mut(&mut self) -> &mut Instance {
-        match self {
-            Self::Instance(i) => i,
-            _ => unreachable!("Expected Instance, found `{}`", self),
-        }
-    }
-
-    pub fn as_class_mut(&mut self) -> &mut Class {
-        match self {
-            Self::Class(c) => c,
-            _ => unreachable!("Expected Class, found `{}`", self),
-        }
-    }
-
-    pub fn upvalue_location(&self) -> &Upvalue {
-        match self {
-            Self::Upvalue(v) => v,
-            _ => unreachable!("Expected upvalue, found `{}`", self),
-        }
-    }
-
-    pub fn upvalue_location_mut(&mut self) -> &mut Upvalue {
-        match self {
-            Self::Upvalue(v) => v,
-            _ => unreachable!("Expected upvalue, found `{}`", self),
-        }
-    }
-
-    pub fn class_name(&self) -> StringId {
-        match &self {
-            Self::Instance(instance) => instance.class.as_class().name,
-            Self::List(list) => list.class.as_class().name,
+impl BoundMethod {
+    fn method_name(&self) -> StringId {
+        match self.method {
+            Value::NativeMethod(native) => native.name,
+            Value::Closure(closure) => closure.function.name,
             x => unreachable!(
-                "Only instances and lists currently have classes. Got `{}`",
+                "Bound method only binds over closures or native methods, got `{}` instead.",
+                x
+            ),
+        }
+    }
+
+    fn receiver_class_name(&self) -> StringId {
+        match self.receiver {
+            Value::Instance(instance) => instance.class.name,
+            Value::List(list) => list.class.name,
+            x => unreachable!(
+                "Bound methods can only have instances or lists as receivers, got `{}` instead.",
                 x
             ),
         }
     }
 }
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Clone)]
+#[derive(Debug, PartialEq, PartialOrd, Clone)]
 pub struct Function {
     pub arity: usize,
     pub chunk: Chunk,
@@ -475,6 +376,12 @@ pub struct NativeFunction {
     pub fun: NativeFunctionImpl,
 }
 
+impl std::fmt::Display for NativeFunction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.pad(&format!("<native fn {}>", *self.name))
+    }
+}
+
 #[derive(Derivative)]
 #[derivative(Debug, PartialEq, PartialOrd, Clone)]
 pub struct NativeMethod {
@@ -491,19 +398,29 @@ pub struct NativeMethod {
     pub fun: NativeMethodImpl,
 }
 
-pub type NativeFunctionImpl = fn(&mut Heap, &[&ValueId]) -> Result<ValueId, String>;
-pub type NativeMethodImpl = fn(&mut Heap, &ValueId, &[&ValueId]) -> Result<ValueId, String>;
+impl std::fmt::Display for NativeMethod {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.pad(&format!(
+            "<native method {} of class {}>",
+            *self.name, *self.class
+        ))
+    }
+}
+
+pub type NativeFunctionImpl = fn(&mut Heap, &[&Value]) -> Result<Value, String>;
+pub type NativeMethodImpl = fn(&mut Heap, &mut Value, &[&Value]) -> Result<Value, String>;
 
 const fn always_equals<T>(_: &T, _: &T) -> bool {
     true
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Derivative)]
+#[derive(Debug, PartialEq, Clone, Derivative)]
 #[derivative(PartialOrd)]
 pub struct Class {
     pub name: StringId,
     #[derivative(PartialOrd = "ignore")]
-    pub methods: HashMap<StringId, ValueId>,
+    // Have to be general Value because it can be a nativemethod(how?) or a closure
+    pub methods: HashMap<StringId, Value>,
     pub is_native: bool,
 }
 
@@ -518,52 +435,34 @@ impl Class {
     }
 }
 
+impl std::fmt::Display for Class {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.pad(&format!("<class {}>", *self.name))
+    }
+}
+
 #[derive(Derivative)]
 #[derivative(Debug, PartialEq, PartialOrd, Clone)]
 pub struct Instance {
-    pub class: ValueId,
+    pub class: ClassId,
     #[derivative(PartialOrd = "ignore")]
-    pub fields: HashMap<String, ValueId>,
+    pub fields: HashMap<String, Value>,
 }
 
 impl Instance {
     #[must_use]
-    pub fn new(class: ValueId) -> Self {
+    pub fn new(class: Value) -> Self {
+        let id = *class.as_class();
         Self {
-            class,
+            class: id,
             fields: HashMap::default(),
         }
     }
 }
 
-#[derive(Debug, PartialOrd, Clone)]
-pub struct BoundMethod {
-    pub receiver: ValueId,
-    pub method: ValueId,
-}
-
-impl BoundMethod {
-    fn method_name(&self) -> StringId {
-        let method = &*self.method;
-        match method {
-            Value::NativeMethod(native) => native.name,
-            Value::Closure(closure) => closure.function.name,
-            x => unreachable!(
-                "Bound method only binds over closures or native methods, got `{}` instead.",
-                x
-            ),
-        }
-    }
-
-    fn receiver_class_name(&self) -> StringId {
-        match &*self.receiver {
-            Value::Instance(instance) => instance.class.as_class().name,
-            Value::List(list) => list.class.as_class().name,
-            x => unreachable!(
-                "Bound methods can only have instances or lists as receivers, got `{}` instead.",
-                x
-            ),
-        }
+impl std::fmt::Display for Instance {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.pad(&format!("<{} instance>", *(self.class.name)))
     }
 }
 
@@ -574,18 +473,200 @@ impl PartialEq for BoundMethod {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Clone)]
+#[derive(Debug, PartialEq, PartialOrd, Clone)]
 pub struct List {
-    pub items: Vec<ValueId>,
-    pub class: ValueId,
+    pub items: Vec<Value>,
+    pub class: ClassId,
 }
 
 impl List {
     #[must_use]
-    pub const fn new(array_class: ValueId) -> Self {
+    pub const fn new(array_class: Value) -> Self {
         Self {
             items: Vec::new(),
-            class: array_class,
+            class: *array_class.as_class(),
+        }
+    }
+}
+
+impl std::fmt::Display for List {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let items = &self.items;
+        let mut comma_separated = String::new();
+        comma_separated.push('[');
+        if !items.is_empty() {
+            for num in &items[0..items.len() - 1] {
+                comma_separated.push_str(&num.to_string());
+                comma_separated.push_str(", ");
+            }
+
+            comma_separated.push_str(&items[items.len() - 1].to_string());
+        }
+        comma_separated.push(']');
+        f.pad(&comma_separated)
+    }
+}
+
+impl From<bool> for Value {
+    fn from(b: bool) -> Self {
+        Self::Bool(b)
+    }
+}
+
+impl From<f64> for Value {
+    fn from(f: f64) -> Self {
+        Self::Number(f.into())
+    }
+}
+
+impl From<i64> for Value {
+    fn from(f: i64) -> Self {
+        Self::Number(f.into())
+    }
+}
+
+impl From<Number> for Value {
+    fn from(n: Number) -> Self {
+        Self::Number(n)
+    }
+}
+
+impl From<StringId> for Value {
+    fn from(s: StringId) -> Self {
+        Self::String(s)
+    }
+}
+
+impl From<FunctionId> for Value {
+    fn from(f: FunctionId) -> Self {
+        Self::Function(f)
+    }
+}
+
+impl From<ClosureId> for Value {
+    fn from(c: ClosureId) -> Self {
+        Self::Closure(c)
+    }
+}
+
+impl From<NativeFunctionId> for Value {
+    fn from(n: NativeFunctionId) -> Self {
+        Self::NativeFunction(n)
+    }
+}
+
+impl From<NativeMethodId> for Value {
+    fn from(n: NativeMethodId) -> Self {
+        Self::NativeMethod(n)
+    }
+}
+
+impl From<UpvalueId> for Value {
+    fn from(u: UpvalueId) -> Self {
+        Self::Upvalue(u)
+    }
+}
+
+impl From<ClassId> for Value {
+    fn from(c: ClassId) -> Self {
+        Self::Class(c)
+    }
+}
+
+impl From<InstanceId> for Value {
+    fn from(i: InstanceId) -> Self {
+        Self::Instance(i)
+    }
+}
+
+impl From<BoundMethodId> for Value {
+    fn from(b: BoundMethodId) -> Self {
+        Self::BoundMethod(b)
+    }
+}
+
+impl From<ListId> for Value {
+    fn from(l: ListId) -> Self {
+        Self::List(l)
+    }
+}
+
+impl Value {
+    pub const fn is_falsey(&self) -> bool {
+        matches!(self, Self::Bool(false) | Self::Nil)
+    }
+
+    pub fn as_closure(&self) -> &ClosureId {
+        match self {
+            Self::Closure(c) => c,
+            _ => unreachable!("Expected Closure, found `{}`", self),
+        }
+    }
+
+    pub fn as_string(&self) -> &StringId {
+        match self {
+            Self::String(s) => s,
+            _ => unreachable!("Expected String, found `{}`", self),
+        }
+    }
+
+    pub fn as_native_method(&self) -> &NativeMethodId {
+        match self {
+            Self::NativeMethod(n) => n,
+            _ => unreachable!("Expected Native, found `{}`", self),
+        }
+    }
+
+    pub fn as_function(&self) -> &FunctionId {
+        match self {
+            Self::Function(f) => f,
+            _ => unreachable!("Expected Function, found `{}`", self),
+        }
+    }
+
+    pub fn as_class(&self) -> &ClassId {
+        match self {
+            Self::Class(c) => c,
+            _ => unreachable!("Expected Class, found `{}`", self),
+        }
+    }
+
+    pub fn as_instance_mut(&mut self) -> &mut InstanceId {
+        match self {
+            Self::Instance(i) => i,
+            _ => unreachable!("Expected Instance, found `{}`", self),
+        }
+    }
+
+    pub fn as_class_mut(&mut self) -> &mut ClassId {
+        match self {
+            Self::Class(c) => c,
+            _ => unreachable!("Expected Class, found `{}`", self),
+        }
+    }
+
+    pub fn upvalue_location(&self) -> &UpvalueId {
+        match self {
+            Self::Upvalue(v) => v,
+            _ => unreachable!("Expected upvalue, found `{}`", self),
+        }
+    }
+
+    pub fn upvalue_location_mut(&mut self) -> &mut UpvalueId {
+        match self {
+            Self::Upvalue(v) => v,
+            _ => unreachable!("Expected upvalue, found `{}`", self),
+        }
+    }
+
+    pub fn class_name(&self) -> StringId {
+        match &self {
+            Self::Instance(instance) => instance.class.name,
+            Self::List(list) => list.class.name,
+            x => unreachable!(
+                "Only instances and lists currently have classes. Got `{}`",
+                x
+            ),
         }
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -5,17 +5,17 @@ use std::pin::Pin;
 use path_slash::PathBufExt;
 use rustc_hash::FxHashMap as HashMap;
 
-use crate::chunk::InstructionDisassembler;
-use crate::heap::{FunctionId, ValueId};
 use crate::native_functions::Natives;
-use crate::value::{Class, Closure, Function, Instance, List, Number, Upvalue};
 use crate::{
-    chunk::{CodeOffset, OpCode},
+    chunk::{CodeOffset, InstructionDisassembler, OpCode},
     compiler::Compiler,
     config,
-    heap::{Heap, StringId},
+    heap::{ClosureId, FunctionId, Heap, StringId, UpvalueId},
     scanner::Scanner,
-    value::{NativeFunction, NativeFunctionImpl, NativeMethod, NativeMethodImpl, Value},
+    value::{
+        Class, Closure, Function, Instance, List, NativeFunction, NativeFunctionImpl, NativeMethod,
+        NativeMethodImpl, Number, Upvalue, Value,
+    },
 };
 
 #[derive(Debug, PartialEq, Eq)]
@@ -46,18 +46,20 @@ macro_rules! binary_op {
 
 type BinaryOp<T> = fn(Number, Number) -> T;
 
+// To modules need to be garbage collected?
 struct Module {
-    name: ValueId,
+    name: StringId,
     path: PathBuf,
 }
 
 struct Global {
-    value: ValueId,
+    value: Value,
     mutable: bool,
 }
 
+// Can probably just be a closureid?
 pub struct CallFrame {
-    closure: ValueId,
+    closure: ClosureId,
     ip: usize,
     stack_base: usize,
     is_module: bool,
@@ -65,13 +67,13 @@ pub struct CallFrame {
 
 impl CallFrame {
     pub fn closure(&self) -> &Closure {
-        (*self.closure).as_closure()
+        &*self.closure
     }
 }
 
 struct CallStack {
     frames: Vec<CallFrame>,
-    current_closure: Option<ValueId>,
+    current_closure: Option<ClosureId>,
     current_function: Option<FunctionId>,
 }
 
@@ -96,19 +98,19 @@ impl CallStack {
     fn pop(&mut self) -> Option<CallFrame> {
         let retval = self.frames.pop();
         self.current_closure = self.frames.last().map(|f| f.closure);
-        self.current_function = self.current_closure.map(|c| c.as_closure().function);
+        self.current_function = self.current_closure.map(|c| c.function);
         retval
     }
 
-    fn push(&mut self, closure: ValueId, stack_base: usize) {
+    fn push(&mut self, closure: ClosureId, stack_base: usize) {
         self.frames.push(CallFrame {
             closure,
             ip: 0,
             stack_base,
-            is_module: closure.as_closure().is_module,
+            is_module: closure.is_module,
         });
         self.current_closure = Some(closure);
-        self.current_function = Some(closure.as_closure().function);
+        self.current_function = Some(closure.function);
     }
 
     fn current_mut(&mut self) -> &mut CallFrame {
@@ -125,7 +127,7 @@ impl CallStack {
         self.current_function.unwrap().chunk.code()[index]
     }
 
-    fn closure(&self) -> ValueId {
+    fn closure(&self) -> ClosureId {
         self.current_closure.unwrap()
     }
 
@@ -141,9 +143,9 @@ impl CallStack {
 pub struct VM {
     heap: Pin<Box<Heap>>,
     callstack: CallStack,
-    stack: Vec<ValueId>,
+    stack: Vec<Value>,
     globals: HashMap<StringId, Global>,
-    open_upvalues: VecDeque<ValueId>,
+    open_upvalues: VecDeque<UpvalueId>,
     natives: Option<Natives>,
     modules: Vec<Module>,
     path: PathBuf,
@@ -194,11 +196,11 @@ impl VM {
             self.define_natives();
             let function_id = self.heap.add_function(function);
 
-            let closure = Closure::new(function_id, true);
+            let closure = Closure::new(*function_id.as_function(), true);
 
             self.add_closure_to_modules(&closure, self.path.clone());
 
-            let value_id = self.heap.add_value(closure.into());
+            let value_id = self.heap.add_closure(closure.into());
             self.stack_push(value_id);
             self.execute_call(value_id, 0);
             self.run()
@@ -238,7 +240,7 @@ impl VM {
                     "          [ { } ]",
                     self.stack
                         .iter()
-                        .map(|v| format!("{}", self.heap.values[v]))
+                        .map(|v| format!("{}", v))
                         .collect::<Vec<_>>()
                         .join(" ][ ")
                 );
@@ -250,9 +252,7 @@ impl VM {
                     self.stack.pop().expect("Stack underflow in OP_POP.");
                 }
                 OpCode::Dup => {
-                    self.stack_push_value(
-                        self.heap.values[self.peek(0).expect("stack underflow in OP_DUP")].clone(),
-                    );
+                    self.stack_push_value(self.peek(0).expect("stack underflow in OP_DUP").clone());
                 }
                 OpCode::DupN => {
                     // -1 because Dup1 should peek at the top most elemnt
@@ -265,8 +265,7 @@ impl VM {
                         // 1 2 3 4 3 (again depth = 1) -> grab 4
                         // 1 2 3 4 3 4
                         self.stack_push_value(
-                            self.heap.values[self.peek(depth).expect("stack underflow in OP_DUP")]
-                                .clone(),
+                            self.peek(depth).expect("stack underflow in OP_DUP").clone(),
                         );
                     }
                 }
@@ -312,9 +311,9 @@ impl VM {
                     }
                 }
                 OpCode::Not => self.not_(),
-                OpCode::Nil => self.stack_push(self.heap.builtin_constants().nil),
-                OpCode::True => self.stack_push(self.heap.builtin_constants().true_),
-                OpCode::False => self.stack_push(self.heap.builtin_constants().false_),
+                OpCode::Nil => self.stack_push(Value::Nil),
+                OpCode::True => self.stack_push(Value::Bool(true)),
+                OpCode::False => self.stack_push(Value::Bool(false)),
                 OpCode::Equal => self.equal(),
                 OpCode::Add => {
                     if let Some(value) = self.add() {
@@ -367,17 +366,16 @@ impl VM {
                         } else {
                             closure
                                 .upvalues
-                                .push((*self.callstack.closure()).as_closure().upvalues[index]);
+                                .push((*self.callstack.closure()).upvalues[index]);
                         }
                     }
-                    let closure_id = self.heap.add_value(Value::from(closure));
+                    let closure_id = self.heap.add_closure(closure);
                     self.stack_push(closure_id);
                 }
                 OpCode::GetUpvalue => {
                     let upvalue_index = usize::from(self.read_byte());
-                    let closure_value = &*self.callstack.closure();
-                    let closure = closure_value.as_closure();
-                    let upvalue_location = closure.upvalues[upvalue_index].upvalue_location();
+                    let closure = *self.callstack.closure();
+                    let upvalue_location = closure.upvalues[upvalue_index];
                     match *upvalue_location {
                         Upvalue::Open(absolute_local_index) => {
                             self.stack_push(self.stack[absolute_local_index]);
@@ -388,18 +386,17 @@ impl VM {
                 OpCode::SetUpvalue => {
                     let upvalue_index = usize::from(self.read_byte());
                     let closure = self.callstack.closure();
-                    let upvalue_location =
-                        closure.as_closure().upvalues[upvalue_index].upvalue_location();
+                    let mut upvalue_location = closure.upvalues[upvalue_index];
                     let new_value = self
                         .stack
                         .last()
-                        .map(|x| self.heap.values[x].clone())
+                        .map(|x| x.clone())
                         .expect("Stack underflow in OP_SET_UPVALUE");
-                    match upvalue_location {
+                    match *upvalue_location {
                         Upvalue::Open(absolute_local_index) => {
-                            *self.stack[*absolute_local_index] = new_value;
+                            self.stack[absolute_local_index] = new_value;
                         }
-                        Upvalue::Closed(mut value_id) => {
+                        Upvalue::Closed(ref mut value_id) => {
                             *value_id = new_value;
                         }
                     }
@@ -410,20 +407,19 @@ impl VM {
                 }
                 OpCode::Class => {
                     let class_name = self.read_string("OP_CLASS");
-                    let class = Class::new(class_name, false);
+                    let class = self.heap.add_class(Class::new(class_name, false));
                     self.stack_push_value(class.into());
                 }
                 OpCode::GetProperty => {
                     let field = self.read_string("GET_PROPERTY");
 
                     // Probaby better to just grab the class and ask if it is native
-                    match &self.heap.values[self.peek(0).expect("Stack underflow in GET_PROPERTY")]
-                    {
+                    match &self.peek(0).expect("Stack underflow in GET_PROPERTY") {
                         Value::Instance(instance) => {
                             if let Some(value) = instance.fields.get(&self.heap.strings[&field]) {
                                 self.stack.pop(); // instance
                                 self.stack_push(*value);
-                            } else if self.bind_method(instance.class, field) {
+                            } else if self.bind_method(instance.class.into(), field) {
                                 // Just using the side effects
                             } else {
                                 runtime_error!(self, "Undefined property '{}'.", *field);
@@ -431,7 +427,7 @@ impl VM {
                             }
                         }
                         Value::List(list) => {
-                            if self.bind_method(list.class, field) {
+                            if self.bind_method(list.class.into(), field) {
                                 // Just using the side effects
                             } else {
                                 runtime_error!(self, "Undefined property '{}'.", *field);
@@ -452,8 +448,7 @@ impl VM {
                 OpCode::SetProperty => {
                     let field_string_id = self.read_string("SET_PROPERTY");
                     let field = &self.heap.strings[&field_string_id];
-                    match &self.heap.values[self.peek(1).expect("Stack underflow in SET_PROPERTY")]
-                    {
+                    match &self.peek(1).expect("Stack underflow in SET_PROPERTY") {
                         Value::Instance(instance) => instance,
                         x => {
                             runtime_error!(
@@ -486,17 +481,16 @@ impl VM {
                 }
                 OpCode::Inherit => {
                     let superclass_id = self.peek(1).expect("Stack underflow in OP_INHERIT");
-                    let superclass =
-                        if let Value::Class(superclass) = &self.heap.values[superclass_id] {
-                            if superclass.is_native {
-                                runtime_error!(self, "Can not inherit from native classes yet.");
-                                return InterpretResult::RuntimeError;
-                            }
-                            superclass
-                        } else {
-                            runtime_error!(self, "Superclass must be a class.");
+                    let superclass = if let Value::Class(superclass) = &superclass_id {
+                        if superclass.is_native {
+                            runtime_error!(self, "Can not inherit from native classes yet.");
                             return InterpretResult::RuntimeError;
-                        };
+                        }
+                        superclass
+                    } else {
+                        runtime_error!(self, "Superclass must be a class.");
+                        return InterpretResult::RuntimeError;
+                    };
                     let methods = superclass.methods.clone();
                     let mut subclass = self.stack.pop().expect("Stack underflow in OP_INHERIT");
                     subclass.as_class_mut().methods.extend(methods);
@@ -529,7 +523,7 @@ impl VM {
                     for _ in 0..arg_count {
                         self.stack.pop();
                     }
-                    self.stack_push_value(list.into());
+                    self.stack_push_value(self.heap.add_list(list).into());
                 }
                 OpCode::IndexSubscript => {
                     if let Some(value) = self.index_subscript() {
@@ -543,9 +537,9 @@ impl VM {
                 }
                 OpCode::Import => {
                     let file_path = self.stack.pop().expect("Stack underflow in OP_IMPORT");
-                    match &*file_path {
+                    match file_path {
                         Value::String(string_id) => {
-                            if let Some(value) = self.import_file(*string_id) {
+                            if let Some(value) = self.import_file(string_id) {
                                 return value;
                             }
                         }
@@ -563,7 +557,7 @@ impl VM {
         }
     }
 
-    fn peek(&self, n: usize) -> Option<&ValueId> {
+    fn peek(&self, n: usize) -> Option<&Value> {
         let len = self.stack.len();
         if n >= len {
             None
@@ -572,7 +566,7 @@ impl VM {
         }
     }
 
-    fn peek_mut(&mut self, n: usize) -> Option<&mut ValueId> {
+    fn peek_mut(&mut self, n: usize) -> Option<&mut Value> {
         let len = self.stack.len();
         if n >= len {
             None
@@ -583,7 +577,7 @@ impl VM {
 
     fn read_string(&mut self, opcode_name: &str) -> StringId {
         let constant = self.read_constant(false);
-        match &self.heap.values[&constant] {
+        match &constant {
             Value::String(string_id) => *string_id,
             x => {
                 panic!("Non-string method name to {opcode_name}: `{x}`");
@@ -593,11 +587,11 @@ impl VM {
 
     fn add_closure_to_modules(&mut self, closure: &Closure, file_path: PathBuf) {
         if closure.is_module {
-            let value_id = self.heap.add_value(closure.function.name.into());
+            let value_id = closure.function.name;
             self.globals.insert(
                 self.heap.builtin_constants().script_name,
                 Global {
-                    value: value_id,
+                    value: value_id.into(),
                     mutable: true,
                 },
             );
@@ -642,14 +636,14 @@ impl VM {
                 };
 
                 if let Some(function) = self.compile(&contents, &name) {
-                    let function_id = self.heap.add_function(function);
-                    let closure = Closure::new(function_id, true);
+                    let function_id = self.heap.add_function(function).as_function();
+                    let closure = Closure::new(*function_id, true);
 
                     if closure.is_module {
                         self.add_closure_to_modules(&closure, file_path);
                     }
 
-                    let value_id = self.heap.add_value(closure.into());
+                    let value_id = self.heap.add_closure(closure);
                     self.stack_push(value_id);
                     self.execute_call(value_id, 0);
                 } else {
@@ -665,11 +659,9 @@ impl VM {
 
         let ok = match &self.stack[slice_start..] {
             [left, right] => {
-                if let (Value::Number(a), Value::Number(b)) =
-                    (&self.heap.values[left], &self.heap.values[right])
-                {
+                if let (Value::Number(a), Value::Number(b)) = (&left, &right) {
                     if int_only
-                        && (!matches!(a, Number::Integer(_)) | !matches!(b, Number::Integer(_)))
+                        & (!matches!(a, Number::Integer(_)) | !matches!(b, Number::Integer(_)))
                     {
                         false
                     } else {
@@ -693,7 +685,7 @@ impl VM {
                 if int_only { "integers" } else { "numbers" },
                 self.stack[slice_start..]
                     .iter()
-                    .map(|v| format!("{}", self.heap.values[v]))
+                    .map(|v| format!("{}", v))
                     .collect::<Vec<_>>()
                     .join(", ")
             );
@@ -704,7 +696,7 @@ impl VM {
     fn add(&mut self) -> Option<InterpretResult> {
         let slice_start = self.stack.len() - 2;
         let ok = match &self.stack[slice_start..] {
-            [left, right] => match (&self.heap.values[left], &self.heap.values[right]) {
+            [left, right] => match (&left, &right) {
                 (Value::Number(a), Value::Number(b)) => {
                     let value = (*a + *b).into();
                     self.stack.pop();
@@ -732,7 +724,7 @@ impl VM {
                 "Operands must be two numbers or two strings. Got: [{}]",
                 self.stack[slice_start..]
                     .iter()
-                    .map(|v| format!("{}", self.heap.values[v]))
+                    .map(|v| format!("{}", v))
                     .collect::<Vec<_>>()
                     .join(", ")
             );
@@ -747,9 +739,7 @@ impl VM {
 
         let ok = match &self.stack[slice_start..] {
             [left, right] => {
-                if let (Value::Number(a), Value::Number(b)) =
-                    (&self.heap.values[left], &self.heap.values[right])
-                {
+                if let (Value::Number(a), Value::Number(b)) = (&left, &right) {
                     let value = a.pow(*b).into();
                     self.stack.pop();
                     self.stack.pop();
@@ -768,7 +758,7 @@ impl VM {
                 "Operands must be numbers. Got: [{}]",
                 self.stack[slice_start..]
                     .iter()
-                    .map(|v| format!("{}", self.heap.values[v]))
+                    .map(|v| format!("{}", v))
                     .collect::<Vec<_>>()
                     .join(", ")
             );
@@ -782,9 +772,7 @@ impl VM {
 
         let ok = match &self.stack[slice_start..] {
             [left, right] => {
-                if let (Value::Number(a), Value::Number(b)) =
-                    (&self.heap.values[left], &self.heap.values[right])
-                {
+                if let (Value::Number(a), Value::Number(b)) = (&left, &right) {
                     let value = a.floor_div(*b).into();
                     self.stack.pop();
                     self.stack.pop();
@@ -803,7 +791,7 @@ impl VM {
                 "Operands must be numbers. Got: [{}]",
                 self.stack[slice_start..]
                     .iter()
-                    .map(|v| format!("{}", self.heap.values[v]))
+                    .map(|v| format!("{}", v))
                     .collect::<Vec<_>>()
                     .join(", ")
             );
@@ -813,10 +801,10 @@ impl VM {
     }
 
     fn index_subscript(&mut self) -> Option<InterpretResult> {
-        let index = match &self.heap.values[&self
+        let index = match &self
             .stack
             .pop()
-            .expect("Stack underflow in OP_INDEX_SUBSCRIPT")]
+            .expect("Stack underflow in OP_INDEX_SUBSCRIPT")
         {
             Value::Number(Number::Integer(n)) => {
                 if let Ok(value) = usize::try_from(*n) {
@@ -837,10 +825,10 @@ impl VM {
             }
         };
 
-        let list = match &self.heap.values[&self
+        let list = match &self
             .stack
             .pop()
-            .expect("Stack underflow in OP_INDEX_SUBSCRIPT")]
+            .expect("Stack underflow in OP_INDEX_SUBSCRIPT")
         {
             Value::List(list) => list,
             x => {
@@ -867,10 +855,10 @@ impl VM {
             .stack
             .pop()
             .expect("Stack underflow in OP_STORE_SUBSCRIPT");
-        let index = match &self.heap.values[&self
+        let index = match &self
             .stack
             .pop()
-            .expect("Stack underflow in OP_STORE_SUBSCRIPT")]
+            .expect("Stack underflow in OP_STORE_SUBSCRIPT")
         {
             Value::Number(Number::Integer(n)) => {
                 if let Ok(value) = usize::try_from(*n) {
@@ -890,10 +878,10 @@ impl VM {
                 return Some(InterpretResult::RuntimeError);
             }
         };
-        let list = match &mut self.heap.values[&self
+        let list = match &mut self
             .stack
             .pop()
-            .expect("Stack underflow in OP_INDEX_SUBSCRIPT")]
+            .expect("Stack underflow in OP_INDEX_SUBSCRIPT")
         {
             Value::List(list) => list,
             x => {
@@ -938,7 +926,7 @@ impl VM {
     fn get_global(&mut self, op: OpCode) -> Option<InterpretResult> {
         let constant_index = self.read_constant_index(op == OpCode::GetGlobalLong);
         let constant_value = self.read_constant_value(constant_index);
-        match &self.heap.values[&constant_value] {
+        match &constant_value {
             Value::String(name) => {
                 if let Some(global) = self.globals.get(name) {
                     self.stack_push(global.value);
@@ -956,7 +944,7 @@ impl VM {
     fn set_global(&mut self, op: OpCode) -> Option<InterpretResult> {
         let constant_index = self.read_constant_index(op == OpCode::SetGlobalLong);
         let constant_value = self.read_constant_value(constant_index);
-        let name = match &self.heap.values[&constant_value] {
+        let name = match &constant_value {
             Value::String(name) => *name,
             x => panic!("Internal error: non-string operand to OP_SET_GLOBAL: {x:?}"),
         };
@@ -980,7 +968,7 @@ impl VM {
 
     fn define_global(&mut self, op: OpCode) {
         let constant = self.read_constant(op == OpCode::DefineGlobalLong);
-        match &self.heap.values[&constant] {
+        match &constant {
             Value::String(name) => {
                 let name = *name;
                 self.globals.insert(
@@ -1062,7 +1050,8 @@ impl VM {
                         .modules
                         .last()
                         .expect("Module underflow in OP_RETURN")
-                        .name,
+                        .name
+                        .into(),
                     mutable: true,
                 },
             );
@@ -1077,7 +1066,7 @@ impl VM {
 
     fn negate(&mut self) -> Option<InterpretResult> {
         let value_id = *self.peek(0).expect("stack underflow in OP_NEGATE");
-        let value = &self.heap.values[&value_id];
+        let value = &value_id;
         if let Value::Number(n) = value {
             self.stack.pop();
             self.stack_push_value((-*n).into());
@@ -1094,7 +1083,7 @@ impl VM {
             .pop()
             .expect("Stack underflow in OP_NOT.")
             .is_falsey();
-        self.stack_push(self.heap.builtin_constants().bool(value));
+        self.stack_push(value.into());
     }
 
     fn equal(&mut self) {
@@ -1106,8 +1095,8 @@ impl VM {
             .stack
             .pop()
             .expect("stack underflow in OP_EQUAL (second)");
-        let left = &self.heap.values[&left_id];
-        let right = &self.heap.values[&right_id];
+        let left = &left_id;
+        let right = &right_id;
 
         // There is one case where equality-by-reference does not imply *actual* equality: NaN
         let value = match (left, right) {
@@ -1119,7 +1108,7 @@ impl VM {
             (left, right) => left_id == right_id || left == right,
         };
 
-        self.stack_push(self.heap.builtin_constants().bool(value));
+        self.stack_push(value.into());
     }
 
     fn read_byte(&mut self) -> u8 {
@@ -1147,17 +1136,17 @@ impl VM {
         }
     }
 
-    fn read_constant_value(&self, index: usize) -> ValueId {
+    fn read_constant_value(&self, index: usize) -> Value {
         *self.callstack.function().chunk.get_constant(index)
     }
 
-    fn read_constant(&mut self, long: bool) -> ValueId {
+    fn read_constant(&mut self, long: bool) -> Value {
         let index = self.read_constant_index(long);
         self.read_constant_value(index)
     }
 
     #[inline]
-    fn stack_push(&mut self, value_id: ValueId) {
+    fn stack_push(&mut self, value_id: Value) {
         self.stack.push(value_id);
         // This check has a pretty big performance overhead; disabled for now
         // TODO find a better way: keep the check and minimize overhead
@@ -1170,16 +1159,14 @@ impl VM {
 
     #[inline]
     fn stack_push_value(&mut self, value: Value) {
-        let value_id = self.heap.add_value(value);
-
-        self.stack.push(value_id);
+        self.stack.push(value);
     }
 
-    fn stack_get(&self, slot: usize) -> &ValueId {
+    fn stack_get(&self, slot: usize) -> &Value {
         &self.stack[self.stack_base() + slot]
     }
 
-    fn stack_get_mut(&mut self, slot: usize) -> &mut ValueId {
+    fn stack_get_mut(&mut self, slot: usize) -> &mut Value {
         let offset = self.stack_base();
         &mut self.stack[offset + slot]
     }
@@ -1188,8 +1175,8 @@ impl VM {
         self.callstack.current().stack_base
     }
 
-    fn call_value(&mut self, callee: ValueId, arg_count: u8) -> bool {
-        match &*callee {
+    fn call_value(&mut self, callee: Value, arg_count: u8) -> bool {
+        match &callee {
             Value::NativeMethod(_) => {
                 println!("Got a native method");
                 false
@@ -1201,14 +1188,14 @@ impl VM {
                 let maybe_initializer = class
                     .methods
                     .get(&self.heap.builtin_constants().init_string);
-                let instance_id: ValueId = self.heap.add_value(Instance::new(callee).into());
+                let mut instance_id = self.heap.add_instance(Instance::new(callee).into());
                 let stack_index = self.stack.len() - usize::from(arg_count) - 1;
                 self.stack[stack_index] = instance_id;
                 if let Some(initializer) = maybe_initializer {
                     if is_native {
                         self.execute_native_method_call(
                             initializer.as_native_method(),
-                            instance_id,
+                            &mut instance_id,
                             arg_count,
                         )
                     } else {
@@ -1221,15 +1208,17 @@ impl VM {
                     true
                 }
             }
-            Value::BoundMethod(bound_method) => match &*bound_method.method {
+            Value::BoundMethod(bound_method) => match &bound_method.method {
                 Value::Closure(_) => {
                     let new_stack_base = self.stack.len() - usize::from(arg_count) - 1;
                     self.stack[new_stack_base] = bound_method.receiver;
                     self.execute_call(bound_method.method, arg_count)
                 }
-                Value::NativeMethod(native_method) => {
-                    self.execute_native_method_call(native_method, bound_method.receiver, arg_count)
-                }
+                Value::NativeMethod(native_method) => self.execute_native_method_call(
+                    native_method,
+                    &mut bound_method.receiver,
+                    arg_count,
+                ),
                 _ => {
                     runtime_error!(
                         self,
@@ -1249,7 +1238,7 @@ impl VM {
     fn execute_native_method_call(
         &mut self,
         f: &NativeMethod,
-        receiver: ValueId,
+        receiver: &mut Value,
         arg_count: u8,
     ) -> bool {
         let arity = f.arity;
@@ -1285,7 +1274,7 @@ impl VM {
         let fun = f.fun;
         let start_index = self.stack.len() - usize::from(arg_count);
         let args = self.stack[start_index..].iter().collect::<Vec<_>>();
-        match fun(&mut self.heap, &receiver, &args) {
+        match fun(&mut self.heap, receiver, &args) {
             Ok(value) => {
                 self.stack
                     .truncate(self.stack.len() - usize::from(arg_count) - 1);
@@ -1346,7 +1335,7 @@ impl VM {
         }
     }
 
-    fn invoke_from_class(&mut self, class: ValueId, method_name: StringId, arg_count: u8) -> bool {
+    fn invoke_from_class(&mut self, class: Value, method_name: StringId, arg_count: u8) -> bool {
         let Some(method) = class.as_class().methods.get(&method_name) else {
             runtime_error!(
                 self,
@@ -1355,11 +1344,11 @@ impl VM {
             );
             return false;
         };
-        match &**method {
+        match method {
             Value::Closure(_) => self.execute_call(*method, arg_count),
             Value::NativeMethod(native) => {
-                let receiver = *self.peek(arg_count as usize).unwrap();
-                self.execute_native_method_call(native, receiver, arg_count)
+                let mut receiver = self.peek(arg_count as usize).unwrap();
+                self.execute_native_method_call(native, &mut receiver, arg_count)
             }
             x => unreachable!(
                 "Can only invoke closure or native methods. Got `{}` instead.",
@@ -1372,23 +1361,23 @@ impl VM {
         let receiver = self
             .peek(arg_count.into())
             .expect("Stack underflow in OP_INVOKE");
-        if let Value::Instance(instance) = &self.heap.values[receiver] {
+        if let Value::Instance(instance) = &receiver {
             if let Some(value) = instance.fields.get(&self.heap.strings[&method_name]) {
                 let new_stack_base = self.stack.len() - usize::from(arg_count) - 1;
                 self.stack[new_stack_base] = *value;
                 self.call_value(*value, arg_count)
             } else {
-                self.invoke_from_class(instance.class, method_name, arg_count)
+                self.invoke_from_class(instance.class.into(), method_name, arg_count)
             }
-        } else if let Value::List(list) = &self.heap.values[receiver] {
-            self.invoke_from_class(list.class, method_name, arg_count)
+        } else if let Value::List(list) = &receiver {
+            self.invoke_from_class(list.class.into(), method_name, arg_count)
         } else {
             runtime_error!(self, "Only instances have methods.");
             false
         }
     }
 
-    fn bind_method(&mut self, class: ValueId, name: StringId) -> bool {
+    fn bind_method(&mut self, class: Value, name: StringId) -> bool {
         let class = class.as_class();
         let Some(method) = class.methods.get(&name) else {
             return false;
@@ -1396,19 +1385,20 @@ impl VM {
         let bound_method = Value::bound_method(
             *self.peek(0).expect("Buffer underflow in OP_METHOD"),
             *method,
+            &mut self.heap,
         );
         self.stack.pop();
         self.stack_push_value(bound_method);
         true
     }
 
-    fn capture_upvalue(&mut self, local: usize) -> ValueId {
+    fn capture_upvalue(&mut self, local: usize) -> UpvalueId {
         let local = self.callstack.current().stack_base + local;
         let mut upvalue_index = 0;
         let mut upvalue = None;
 
         for (i, this) in self.open_upvalues.iter().enumerate() {
-            if this.upvalue_location().as_open() <= local {
+            if this.as_open() <= local {
                 break;
             }
             upvalue = Some(this);
@@ -1416,33 +1406,34 @@ impl VM {
         }
 
         if let Some(upvalue) = upvalue {
-            if upvalue.upvalue_location().as_open() == local {
+            if upvalue.as_open() == local {
                 return *upvalue;
             }
         }
 
-        let upvalue = Value::Upvalue(Upvalue::Open(local));
-        let upvalue_id = self.heap.add_value(upvalue);
-        self.open_upvalues.insert(upvalue_index, upvalue_id);
+        let upvalue_id = self
+            .heap
+            .add_upvalue(Upvalue::Open(local))
+            .upvalue_location();
+        self.open_upvalues.insert(upvalue_index, *upvalue_id);
 
-        upvalue_id
+        *upvalue_id
     }
 
     fn close_upvalue(&mut self, last: usize) {
         while self
             .open_upvalues
             .front()
-            .map_or(false, |v| v.upvalue_location().as_open() >= last)
+            .map_or(false, |v| v.as_open() >= last)
         {
             let mut upvalue = self.open_upvalues.pop_front().unwrap();
-            debug_assert!(matches!(*upvalue, Value::Upvalue(_)));
 
-            let pointed_value = self.stack[upvalue.upvalue_location().as_open()];
-            *upvalue.upvalue_location_mut() = Upvalue::Closed(pointed_value);
+            let pointed_value = self.stack[upvalue.as_open()];
+            *upvalue = Upvalue::Closed(pointed_value);
         }
     }
 
-    fn execute_call(&mut self, closure_id: ValueId, arg_count: u8) -> bool {
+    fn execute_call(&mut self, closure_id: Value, arg_count: u8) -> bool {
         let closure = closure_id.as_closure();
         let arity = closure.function.arity;
         let arg_count = usize::from(arg_count);
@@ -1469,13 +1460,13 @@ impl VM {
         }
 
         debug_assert!(
-            matches!(*closure_id, Value::Closure(_)),
+            matches!(closure_id, Value::Closure(_)),
             "`execute_call` must be called with a `Closure`, got: {}",
-            *closure_id
+            closure_id
         );
 
         self.callstack
-            .push(closure_id, self.stack.len() - arg_count - 1);
+            .push(*closure_id.as_closure(), self.stack.len() - arg_count - 1);
         true
     }
 
@@ -1485,20 +1476,20 @@ impl VM {
         arity: &'static [u8],
         fun: NativeFunctionImpl,
     ) {
-        let value = Value::NativeFunction(NativeFunction { name, arity, fun });
-        let value_id = self.heap.add_value(value);
+        let value = self
+            .heap
+            .add_native_function(NativeFunction { name, arity, fun });
         self.globals.insert(
             name,
             Global {
-                value: value_id,
+                value: value,
                 mutable: true,
             },
         );
     }
 
     pub fn define_native_class(&mut self, name_id: StringId) {
-        let value = Value::Class(Class::new(name_id, true));
-        let value_id = self.heap.add_value(value);
+        let value_id = self.heap.add_class(Class::new(name_id, true));
         self.globals.insert(
             name_id,
             Global {
@@ -1518,13 +1509,12 @@ impl VM {
         arity: &'static [u8],
         fun: NativeMethodImpl,
     ) {
-        let value = Value::NativeMethod(NativeMethod {
+        let value_id = self.heap.add_native_method(NativeMethod {
             class,
             name,
             arity,
             fun,
         });
-        let value_id = self.heap.add_value(value);
         let target_class = self
             .heap
             .native_classes
@@ -1554,10 +1544,10 @@ impl VM {
             self.heap.mark_function(&frame.closure().function);
         }
         for upvalue in &self.open_upvalues {
-            self.heap.mark_value(upvalue);
+            self.heap.mark_upvalue(upvalue);
         }
         for value in &self.modules {
-            self.heap.mark_value(&value.name);
+            self.heap.mark_string(&value.name);
         }
 
         // Trace references

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -396,8 +396,8 @@ impl VM {
                         Upvalue::Open(absolute_local_index) => {
                             self.stack[absolute_local_index] = new_value;
                         }
-                        Upvalue::Closed(ref mut value_id) => {
-                            *value_id = new_value;
+                        Upvalue::Closed(ref mut value) => {
+                            *value = new_value;
                         }
                     }
                 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -240,7 +240,7 @@ impl VM {
                     "          [ { } ]",
                     self.stack
                         .iter()
-                        .map(|v| format!("{}", v))
+                        .map(|v| format!("{v}"))
                         .collect::<Vec<_>>()
                         .join(" ][ ")
                 );
@@ -687,7 +687,7 @@ impl VM {
                 if int_only { "integers" } else { "numbers" },
                 self.stack[slice_start..]
                     .iter()
-                    .map(|v| format!("{}", v))
+                    .map(|v| format!("{v}"))
                     .collect::<Vec<_>>()
                     .join(", ")
             );
@@ -726,7 +726,7 @@ impl VM {
                 "Operands must be two numbers or two strings. Got: [{}]",
                 self.stack[slice_start..]
                     .iter()
-                    .map(|v| format!("{}", v))
+                    .map(|v| format!("{v}"))
                     .collect::<Vec<_>>()
                     .join(", ")
             );
@@ -760,7 +760,7 @@ impl VM {
                 "Operands must be numbers. Got: [{}]",
                 self.stack[slice_start..]
                     .iter()
-                    .map(|v| format!("{}", v))
+                    .map(|v| format!("{v}"))
                     .collect::<Vec<_>>()
                     .join(", ")
             );
@@ -793,7 +793,7 @@ impl VM {
                 "Operands must be numbers. Got: [{}]",
                 self.stack[slice_start..]
                     .iter()
-                    .map(|v| format!("{}", v))
+                    .map(|v| format!("{v}"))
                     .collect::<Vec<_>>()
                     .join(", ")
             );
@@ -1459,8 +1459,7 @@ impl VM {
 
         debug_assert!(
             matches!(closure_id, Value::Closure(_)),
-            "`execute_call` must be called with a `Closure`, got: {}",
-            closure_id
+            "`execute_call` must be called with a `Closure`, got: {closure_id}"
         );
 
         self.callstack

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1,4 +1,3 @@
-use std::borrow::Borrow;
 use std::collections::VecDeque;
 use std::path::PathBuf;
 use std::pin::Pin;
@@ -377,11 +376,11 @@ impl VM {
                     let upvalue_index = usize::from(self.read_byte());
                     let closure = self.callstack.closure();
                     let upvalue_location = closure.upvalues[upvalue_index];
-                    match &**upvalue_location.borrow() {
+                    match *upvalue_location {
                         Upvalue::Open(absolute_local_index) => {
-                            self.stack_push(self.stack[*absolute_local_index]);
+                            self.stack_push(self.stack[absolute_local_index]);
                         }
-                        Upvalue::Closed(value) => self.stack_push(*value.borrow()),
+                        Upvalue::Closed(value) => self.stack_push(value),
                     }
                 }
                 OpCode::SetUpvalue => {
@@ -398,7 +397,7 @@ impl VM {
                             self.stack[absolute_local_index] = new_value;
                         }
                         Upvalue::Closed(ref mut value) => {
-                            value.replace(new_value);
+                            *value = new_value;
                         }
                     }
                 }
@@ -1428,7 +1427,7 @@ impl VM {
             let mut upvalue = self.open_upvalues.pop_front().unwrap();
 
             let pointed_value = self.stack[upvalue.as_open()];
-            *upvalue = Upvalue::Closed(pointed_value.into());
+            *upvalue = Upvalue::Closed(pointed_value);
         }
     }
 

--- a/test/closure/assign_captured.gen
+++ b/test/closure/assign_captured.gen
@@ -1,0 +1,23 @@
+var get;
+var set;
+
+fun outer() {
+  var x = "before";
+  var y = "before";
+  fun inner() {
+    x = "assigned";
+  }
+  fun inner_set() {
+    y = "assigned";
+  }
+  fun inner_get() {
+    print(y);
+  }
+  get = inner_get;
+  set = inner_set;
+  inner();
+  print(x);
+}
+var my_inners = outer(); # expect: assigned
+set();
+get(); # expect: assigned

--- a/test/closure/assign_to_closure.gen
+++ b/test/closure/assign_to_closure.gen
@@ -5,14 +5,13 @@ var g;
   var local = "local";
   fun f_() {
     print(local);
-    local = "after f";
+    local = 3;
     print(local);
   }
   f = f_;
-
   fun g_() {
     print(local);
-    local = "after g";
+    local = 15.0;
     print(local);
   }
   g = g_;
@@ -20,8 +19,8 @@ var g;
 
 f();
 # expect: local
-# expect: after f
+# expect: 3
 
 g();
-# expect: after f
-# expect: after g
+# expect: 3
+# expect: 15.0

--- a/test/closure/delayed_closure_change.gen
+++ b/test/closure/delayed_closure_change.gen
@@ -1,0 +1,25 @@
+fun outer() {
+  var x = "value";
+  fun middle() {
+    fun inner() {
+      print(x);
+      x = "new value";
+    }
+
+    print("create inner closure");
+    print(x);
+    return inner;
+  }
+
+  print("return from outer");
+  return middle;
+}
+
+var mid = outer(); # expect: return from outer
+var inner2 = mid();
+# expect: create inner closure
+# expect: value
+inner2(); # expect: value
+mid();
+# expect: create inner closure
+# expect: new value


### PR DESCRIPTION
Now Values are what is being passed around. This means that the Numbers, Bools and Nil can just be passed on the stack.

Everything else contains an ID that points into a respective arena.

Arenas are still in the ids with the raw pointers.
Could at some point move that to a Rc<RefCell>> or just use explicit calls that include the heap/arena to get the actual values.