### PR TITLE
Cleanup equality check and benchmarks

### DIFF
--- a/benchmark/binary_trees.gen
+++ b/benchmark/binary_trees.gen
@@ -26,16 +26,8 @@ var minDepth = 4;
 var maxDepth = 9;
 var stretchDepth = maxDepth + 1;
 
-var start = clock();
-
-# print("stretch tree of depth:");
-# print(stretchDepth);
-# print("check:");
-# print(Tree(0, stretchDepth).check());
-
 var longLivedTree = Tree(0, maxDepth);
 
-# iterations = 2 ** maxDepth
 var iterations = 1;
 var d = 0;
 while (d < maxDepth) {
@@ -52,20 +44,6 @@ while (depth < stretchDepth) {
     i = i + 1;
   }
 
-  # print("num trees:");
-  # print(iterations * 2);
-  # print("depth:");
-  # print(depth);
-  # print("check:");
-  # print(check);
-
   iterations = iterations / 4;
   depth = depth + 2;
 }
-
-# print("long lived tree of depth:");
-# print(maxDepth);
-# print("check:");
-# print(longLivedTree.check());
-# print("elapsed:");
-# print(clock() - start);

--- a/benchmark/binary_trees.lox.nom
+++ b/benchmark/binary_trees.lox.nom
@@ -26,16 +26,8 @@ var minDepth = 4;
 var maxDepth = 9;
 var stretchDepth = maxDepth + 1;
 
-var start = clock();
-
-// print("stretch tree of depth:");
-// print(stretchDepth);
-// print("check:");
-// print(Tree(0, stretchDepth).check());
-
 var longLivedTree = Tree(0, maxDepth);
 
-// iterations = 2 ** maxDepth
 var iterations = 1;
 var d = 0;
 while (d < maxDepth) {
@@ -52,20 +44,6 @@ while (depth < stretchDepth) {
     i = i + 1;
   }
 
-  // print("num trees:");
-  // print(iterations * 2);
-  // print("depth:");
-  // print(depth);
-  // print("check:");
-  // print(check);
-
   iterations = iterations / 4;
   depth = depth + 2;
 }
-
-// print("long lived tree of depth:");
-// print(maxDepth);
-// print("check:");
-// print(longLivedTree.check());
-// print("elapsed:");
-// print(clock() - start);

--- a/benchmark/equality.gen
+++ b/benchmark/equality.gen
@@ -1,20 +1,5 @@
 var i = 0;
 
-var loopStart = clock();
-
-while (i < 1000000) {
-  i = i + 1;
-
-  1; 1; 1; 2; 1; nil; 1; "str"; 1; true;
-  nil; nil; nil; 1; nil; "str"; nil; true;
-  true; true; true; 1; true; false; true; "str"; true; nil;
-  "str"; "str"; "str"; "stru"; "str"; 1; "str"; nil; "str"; true;
-}
-
-var loopTime = clock() - loopStart;
-
-var start = clock();
-
 i = 0;
 while (i < 1000000) {
   i = i + 1;
@@ -24,11 +9,3 @@ while (i < 1000000) {
   true == true; true == 1; true == false; true == "str"; true == nil;
   "str" == "str"; "str" == "stru"; "str" == 1; "str" == nil; "str" == true;
 }
-
-var elapsed = clock() - start;
-# print("loop");
-# print(loopTime);
-# print("elapsed");
-# print(elapsed);
-# print("equals");
-# print(elapsed - loopTime);

--- a/benchmark/equality.lox.nom
+++ b/benchmark/equality.lox.nom
@@ -1,20 +1,5 @@
 var i = 0;
 
-var loopStart = clock();
-
-while (i < 1000000) {
-  i = i + 1;
-
-  1; 1; 1; 2; 1; nil; 1; "str"; 1; true;
-  nil; nil; nil; 1; nil; "str"; nil; true;
-  true; true; true; 1; true; false; true; "str"; true; nil;
-  "str"; "str"; "str"; "stru"; "str"; 1; "str"; nil; "str"; true;
-}
-
-var loopTime = clock() - loopStart;
-
-var start = clock();
-
 i = 0;
 while (i < 1000000) {
   i = i + 1;
@@ -24,11 +9,3 @@ while (i < 1000000) {
   true == true; true == 1; true == false; true == "str"; true == nil;
   "str" == "str"; "str" == "stru"; "str" == 1; "str" == nil; "str" == true;
 }
-
-var elapsed = clock() - start;
-// print("loop");
-// print(loopTime);
-// print("elapsed");
-// print(elapsed);
-// print("equals");
-// print(elapsed - loopTime);

--- a/benchmark/instantiation.gen
+++ b/benchmark/instantiation.gen
@@ -4,7 +4,6 @@ class Foo {
   __init__() {}
 }
 
-var start = clock();
 var i = 0;
 while (i < 50000) {
   Foo();
@@ -39,5 +38,3 @@ while (i < 50000) {
   Foo();
   i = i + 1;
 }
-
-# print(clock() - start);

--- a/benchmark/instantiation.lox.nom
+++ b/benchmark/instantiation.lox.nom
@@ -4,7 +4,6 @@ class Foo {
   init() {}
 }
 
-var start = clock();
 var i = 0;
 while (i < 50000) {
   Foo();
@@ -39,5 +38,3 @@ while (i < 50000) {
   Foo();
   i = i + 1;
 }
-
-// print(clock() - start);

--- a/benchmark/invocation.gen
+++ b/benchmark/invocation.gen
@@ -34,7 +34,6 @@ class Foo {
 }
 
 var foo = Foo();
-var start = clock();
 var i = 0;
 while (i < 50000) {
   foo.method0();
@@ -69,5 +68,3 @@ while (i < 50000) {
   foo.method29();
   i = i + 1;
 }
-
-# print(clock() - start);

--- a/benchmark/invocation.lox.nom
+++ b/benchmark/invocation.lox.nom
@@ -34,7 +34,6 @@ class Foo {
 }
 
 var foo = Foo();
-var start = clock();
 var i = 0;
 while (i < 50000) {
   foo.method0();
@@ -69,5 +68,3 @@ while (i < 50000) {
   foo.method29();
   i = i + 1;
 }
-
-// print(clock() - start);

--- a/benchmark/method_call.gen
+++ b/benchmark/method_call.gen
@@ -29,7 +29,6 @@ class NthToggle < Toggle {
   }
 }
 
-var start = clock();
 var n = 10000;
 var val = true;
 var toggle = Toggle(val);
@@ -47,8 +46,6 @@ for (var i = 0; i < n; i = i + 1) {
   val = toggle.activate().value();
 }
 
-# print(toggle.value());
-
 val = true;
 var ntoggle = NthToggle(val, 3);
 
@@ -64,6 +61,3 @@ for (var i = 0; i < n; i = i + 1) {
   val = ntoggle.activate().value();
   val = ntoggle.activate().value();
 }
-
-# print(ntoggle.value());
-# print(clock() - start);

--- a/benchmark/method_call.lox.nom
+++ b/benchmark/method_call.lox.nom
@@ -29,7 +29,6 @@ class NthToggle < Toggle {
   }
 }
 
-var start = clock();
 var n = 10000;
 var val = true;
 var toggle = Toggle(val);
@@ -47,8 +46,6 @@ for (var i = 0; i < n; i = i + 1) {
   val = toggle.activate().value();
 }
 
-// print(toggle.value());
-
 val = true;
 var ntoggle = NthToggle(val, 3);
 
@@ -64,6 +61,3 @@ for (var i = 0; i < n; i = i + 1) {
   val = ntoggle.activate().value();
   val = ntoggle.activate().value();
 }
-
-// print(ntoggle.value());
-// print(clock() - start);

--- a/benchmark/properties.gen
+++ b/benchmark/properties.gen
@@ -67,7 +67,6 @@ class Foo {
 }
 
 var foo = Foo();
-var start = clock();
 var i = 0;
 while (i < 50000) {
   foo.method0();
@@ -102,5 +101,3 @@ while (i < 50000) {
   foo.method29();
   i = i + 1;
 }
-
-# print(clock() - start);

--- a/benchmark/properties.lox.nom
+++ b/benchmark/properties.lox.nom
@@ -67,7 +67,6 @@ class Foo {
 }
 
 var foo = Foo();
-var start = clock();
 var i = 0;
 while (i < 50000) {
   foo.method0();
@@ -102,5 +101,3 @@ while (i < 50000) {
   foo.method29();
   i = i + 1;
 }
-
-// print(clock() - start);

--- a/benchmark/string_equality.gen
+++ b/benchmark/string_equality.gen
@@ -5,7 +5,7 @@ var a4 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa4";
 var a5 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa5";
 var a6 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa6";
 var a7 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa7";
-var a8 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa8";
+var a8 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1";
 
 var i = 0;
 while (i < 10000) {

--- a/benchmark/string_equality.lox.nom
+++ b/benchmark/string_equality.lox.nom
@@ -5,7 +5,7 @@ var a4 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa4";
 var a5 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa5";
 var a6 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa6";
 var a7 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa7";
-var a8 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa8";
+var a8 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1";
 
 var i = 0;
 while (i < 10000) {

--- a/benchmark/trees.gen
+++ b/benchmark/trees.gen
@@ -24,10 +24,8 @@ class Tree {
 }
 
 var tree = Tree(8);
-var start = clock();
 for (var i = 0; i < 10; i = i + 1) {
   if (tree.walk() != 122068) {
     print("Error");
   }
 }
-# print(clock() - start);

--- a/benchmark/trees.lox.nom
+++ b/benchmark/trees.lox.nom
@@ -11,7 +11,9 @@ class Tree {
   }
 
   walk() {
-    if (this.depth == 0) return 0;
+    if (this.depth == 0) {
+      return 0;
+    }
     return this.depth
         + this.a.walk()
         + this.b.walk()
@@ -22,8 +24,8 @@ class Tree {
 }
 
 var tree = Tree(8);
-var start = clock();
 for (var i = 0; i < 10; i = i + 1) {
-  if (tree.walk() != 122068) print("Error");
+  if (tree.walk() != 122068) {
+    print("Error");
+  }
 }
-// print(clock() - start);

--- a/benchmark/zoo.gen
+++ b/benchmark/zoo.gen
@@ -17,7 +17,6 @@ class Zoo {
 
 var zoo = Zoo();
 var sum = 0;
-var start = clock();
 while (sum < 1000000) {
   sum = sum + zoo.ant()
             + zoo.banana()
@@ -26,6 +25,3 @@ while (sum < 1000000) {
             + zoo.grass()
             + zoo.mouse();
 }
-
-# print(sum);
-# print(clock() - start);

--- a/benchmark/zoo.lox.nom
+++ b/benchmark/zoo.lox.nom
@@ -17,7 +17,6 @@ class Zoo {
 
 var zoo = Zoo();
 var sum = 0;
-var start = clock();
 while (sum < 1000000) {
   sum = sum + zoo.ant()
             + zoo.banana()
@@ -26,6 +25,3 @@ while (sum < 1000000) {
             + zoo.grass()
             + zoo.mouse();
 }
-
-// print(sum);
-// print(clock() - start);

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -32,21 +32,20 @@ new_key_type! {
     pub struct BoundMethodKey;
 }
 
-#[derive(Clone, Debug, PartialOrd, Derivative)]
+#[derive(Clone, PartialOrd, Debug, Derivative)]
 #[derivative(Hash)]
 pub struct ArenaId<K: Key, T: ArenaValue> {
     id: K,
-    #[derivative(Hash = "ignore")]
-    pub arena: NonNull<Arena<K, T>>, // Yes this is terrible, yes I'm OK with it for this projec
-                                     // These could be but then i would have to put `clones` everywhere.
-                                     // use std::cell::RefCell;
-                                     // use std::rc::Rc;
-                                     // pub arena: Rc<RefCell<Arena<K, T>>>,
+    // Yes this is terrible, yes I'm OK with it for this projec
+    // These could be but then i would have to put `clones` everywhere.
+    // use std::cell::RefCell;
+    // use std::rc::Rc;
+    // pub arena: Rc<RefCell<Arena<K, T>>>,
+    pub arena: NonNull<Arena<K, T>>,
 }
 
 impl<K: Key, T: ArenaValue> PartialEq for ArenaId<K, T> {
     fn eq(&self, other: &Self) -> bool {
-        // Two different bound methods are always considered different
         self.id == other.id || **self == **other
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1096,20 +1096,7 @@ impl VM {
             .stack
             .pop()
             .expect("stack underflow in OP_EQUAL (second)");
-        let left = &left_id;
-        let right = &right_id;
-
-        // There is one case where equality-by-reference does not imply *actual* equality: NaN
-        let value = match (left, right) {
-            (Value::Number(Number::Float(left)), Value::Number(Number::Float(right)))
-                if left.is_nan() && right.is_nan() =>
-            {
-                false
-            }
-            (left, right) => left_id == right_id || left == right,
-        };
-
-        self.stack_push(value.into());
+        self.stack_push((left_id == right_id).into());
     }
 
     fn read_byte(&mut self) -> u8 {

--- a/test/operator/equals.gen
+++ b/test/operator/equals.gen
@@ -6,6 +6,11 @@ print(true == false); # expect: false
 print(1 == 1); # expect: true
 print(1 == 2); # expect: false
 
+print(1.0 == 1.0); # expect: true
+print(1.0 == 2.0); # expect: false
+
+print(0.0/0.0 == 0.0/0.0); # expect: false
+
 print("str" == "str"); # expect: true
 print("str" == "ing"); # expect: false
 


### PR DESCRIPTION
Equality checks were already implemented properly, except for an unnecessary NaN check.

Also cleaned up the benchmarks a bit removing calls to clock and making the syntax identical (makes parsing more fair although that should be an irrelevant portion to the runtime)